### PR TITLE
Insert storage contents into reagent grinder

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
@@ -333,7 +333,7 @@ namespace Content.Server.Kitchen.EntitySystems
 
             args.Handled = true;
         }
-        // Carpmosia-end
+        // Carpmosia-end - Insert storage contents into reagent grinder
 
         /// <summary>
         /// The wzhzhzh of the grinder. Processes the contents of the grinder and puts the output in the beaker.

--- a/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
@@ -6,7 +6,7 @@ using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Destructible;
-using Content.Shared.DoAfter;
+using Content.Shared.DoAfter; // Carpmosia - Insert storage contents into reagent grinder
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Kitchen;
@@ -25,7 +25,7 @@ using Content.Server.Construction.Completions;
 using Content.Server.Jittering;
 using Content.Shared.Jittering;
 using Content.Shared.Power;
-using Content.Shared.Storage;
+using Content.Shared.Storage; // Carpmosia - Insert storage contents into reagent grinder
 
 namespace Content.Server.Kitchen.EntitySystems
 {
@@ -42,7 +42,7 @@ namespace Content.Server.Kitchen.EntitySystems
         [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
         [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
         [Dependency] private readonly SharedDestructibleSystem _destructible = default!;
-        [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
+        [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!; // Carpmosia - Insert storage contents into reagent grinder
         [Dependency] private readonly RandomHelperSystem _randomHelper = default!;
         [Dependency] private readonly JitteringSystem _jitter = default!;
 
@@ -64,7 +64,7 @@ namespace Content.Server.Kitchen.EntitySystems
             SubscribeLocalEvent<ReagentGrinderComponent, ReagentGrinderStartMessage>(OnStartMessage);
             SubscribeLocalEvent<ReagentGrinderComponent, ReagentGrinderEjectChamberAllMessage>(OnEjectChamberAllMessage);
             SubscribeLocalEvent<ReagentGrinderComponent, ReagentGrinderEjectChamberContentMessage>(OnEjectChamberContentMessage);
-            SubscribeLocalEvent<ReagentGrinderComponent, ContainerDoAfterEvent>(OnContainerDoAfter);
+            SubscribeLocalEvent<ReagentGrinderComponent, ContainerDoAfterEvent>(OnContainerDoAfter); // Carpmosia - Insert storage contents into reagent grinder
         }
 
         private void OnToggleAutoModeMessage(Entity<ReagentGrinderComponent> entity, ref ReagentGrinderToggleAutoModeMessage message)
@@ -179,6 +179,7 @@ namespace Content.Server.Kitchen.EntitySystems
 
             if (!HasComp<ExtractableComponent>(heldEnt))
             {
+                // Carpmosia-start - Insert storage contents into reagent grinder
                 if (HasComp<StorageComponent>(heldEnt))
                 {
                     var doAfter = new DoAfterArgs(EntityManager, args.User, 0.5f, new ContainerDoAfterEvent(), entity, entity, used: heldEnt)
@@ -192,6 +193,7 @@ namespace Content.Server.Kitchen.EntitySystems
                 }
 
                 else if (!HasComp<FitsInDispenserComponent>(heldEnt))
+                // Carpmosia-end
                 {
                     // This is ugly but we can't use whitelistFailPopup because there are 2 containers with different whitelists.
                     _popupSystem.PopupEntity(Loc.GetString("reagent-grinder-component-cannot-put-entity-message"), entity.Owner, args.User);
@@ -290,14 +292,7 @@ namespace Content.Server.Kitchen.EntitySystems
                 UpdateUiState(entity);
             }
         }
-
-        /// <summary>
-        /// DoAfter function for interacting with the grinder with an item with a storage component.
-        /// Moves any Extractable items from the storage of the held item to the grinder's container.
-        /// </summary>
-        /// <param name="uid">The grinder</param>
-        /// <param name="comp">The grinder component</param>
-        /// <param name="args">DoAfter args</param>
+        // Carpmosia-start - Insert storage contents into reagent grinder
         private void OnContainerDoAfter(EntityUid uid, ReagentGrinderComponent comp, ContainerDoAfterEvent args)
         {
             // If there's no storage component, we leave
@@ -331,6 +326,7 @@ namespace Content.Server.Kitchen.EntitySystems
 
             args.Handled = true;
         }
+        // Carpmosia-end
 
         /// <summary>
         /// The wzhzhzh of the grinder. Processes the contents of the grinder and puts the output in the beaker.

--- a/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
@@ -293,6 +293,13 @@ namespace Content.Server.Kitchen.EntitySystems
             }
         }
         // Carpmosia-start - Insert storage contents into reagent grinder
+        /// <summary>
+        /// DoAfter function for interacting with the grinder with an item with a storage component.
+        /// Moves any Extractable items from the storage of the held item to the grinder's container.
+        /// </summary>
+        /// <param name="uid">The grinder uid</param>
+        /// <param name="comp">The grinder component</param>
+        /// <param name="args">DoAfter args</param>
         private void OnContainerDoAfter(EntityUid uid, ReagentGrinderComponent comp, ContainerDoAfterEvent args)
         {
             // If there's no storage component, we leave

--- a/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Destructible;
+using Content.Shared.DoAfter; // Carpmosia - Insert storage contents into reagent grinder
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Kitchen;
@@ -24,6 +25,7 @@ using Content.Server.Construction.Completions;
 using Content.Server.Jittering;
 using Content.Shared.Jittering;
 using Content.Shared.Power;
+using Content.Shared.Storage; // Carpmosia - Insert storage contents into reagent grinder
 
 namespace Content.Server.Kitchen.EntitySystems
 {
@@ -40,6 +42,7 @@ namespace Content.Server.Kitchen.EntitySystems
         [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
         [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
         [Dependency] private readonly SharedDestructibleSystem _destructible = default!;
+        [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!; // Carpmosia - Insert storage contents into reagent grinder
         [Dependency] private readonly RandomHelperSystem _randomHelper = default!;
         [Dependency] private readonly JitteringSystem _jitter = default!;
 
@@ -61,6 +64,7 @@ namespace Content.Server.Kitchen.EntitySystems
             SubscribeLocalEvent<ReagentGrinderComponent, ReagentGrinderStartMessage>(OnStartMessage);
             SubscribeLocalEvent<ReagentGrinderComponent, ReagentGrinderEjectChamberAllMessage>(OnEjectChamberAllMessage);
             SubscribeLocalEvent<ReagentGrinderComponent, ReagentGrinderEjectChamberContentMessage>(OnEjectChamberContentMessage);
+            SubscribeLocalEvent<ReagentGrinderComponent, ContainerDoAfterEvent>(OnContainerDoAfter); // Carpmosia - Insert storage contents into reagent grinder
         }
 
         private void OnToggleAutoModeMessage(Entity<ReagentGrinderComponent> entity, ref ReagentGrinderToggleAutoModeMessage message)
@@ -175,7 +179,21 @@ namespace Content.Server.Kitchen.EntitySystems
 
             if (!HasComp<ExtractableComponent>(heldEnt))
             {
-                if (!HasComp<FitsInDispenserComponent>(heldEnt))
+                // Carpmosia-start - Insert storage contents into reagent grinder
+                if (HasComp<StorageComponent>(heldEnt))
+                {
+                    var doAfter = new DoAfterArgs(EntityManager, args.User, 0.5f, new ContainerDoAfterEvent(), entity, entity, used: heldEnt)
+                    {
+                        BreakOnDamage = true,
+                        NeedHand = true,
+                        BreakOnMove = true,
+                        BreakOnWeightlessMove = true,
+                    };
+                    _doAfterSystem.TryStartDoAfter(doAfter);
+                }
+
+                else if (!HasComp<FitsInDispenserComponent>(heldEnt))
+                // Carpmosia-end
                 {
                     // This is ugly but we can't use whitelistFailPopup because there are 2 containers with different whitelists.
                     _popupSystem.PopupEntity(Loc.GetString("reagent-grinder-component-cannot-put-entity-message"), entity.Owner, args.User);
@@ -274,6 +292,41 @@ namespace Content.Server.Kitchen.EntitySystems
                 UpdateUiState(entity);
             }
         }
+        // Carpmosia-start - Insert storage contents into reagent grinder
+        private void OnContainerDoAfter(EntityUid uid, ReagentGrinderComponent comp, ContainerDoAfterEvent args)
+        {
+            // If there's no storage component, we leave
+            if (!TryComp<StorageComponent>(args.Used, out var storage))
+                return;
+
+            // If the storage is empty, we leave
+            if (storage.StoredItems.Count == 0)
+                return;
+
+            var inputContainer = _containerSystem.EnsureContainer<Container>(comp.Owner, SharedReagentGrinder.InputContainerId);
+
+            // Find every Extractable item and put it into the grinder
+            foreach (var (item, _location) in storage.StoredItems)
+            {
+                // If the grinder is full, leave
+                if (inputContainer.ContainedEntities.Count >= comp.StorageMaxEntities)
+                {
+                    _popupSystem.PopupEntity(Loc.GetString("reagent-grinder-component-storage-full-message"), comp.Owner, args.User);
+                    return;
+                }
+
+                // If it isn't extractable, skip it
+                if (!HasComp<ExtractableComponent>(item))
+                    continue;
+
+                // Try to insert the item. If we can't, escape out of this function
+                if (!_containerSystem.Insert(item, inputContainer))
+                    return;
+            }
+
+            args.Handled = true;
+        }
+        // Carpmosia-end
 
         /// <summary>
         /// The wzhzhzh of the grinder. Processes the contents of the grinder and puts the output in the beaker.

--- a/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
@@ -6,7 +6,7 @@ using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Destructible;
-using Content.Shared.DoAfter; // Carpmosia - Insert storage contents into reagent grinder
+using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Kitchen;
@@ -25,7 +25,7 @@ using Content.Server.Construction.Completions;
 using Content.Server.Jittering;
 using Content.Shared.Jittering;
 using Content.Shared.Power;
-using Content.Shared.Storage; // Carpmosia - Insert storage contents into reagent grinder
+using Content.Shared.Storage;
 
 namespace Content.Server.Kitchen.EntitySystems
 {
@@ -42,7 +42,7 @@ namespace Content.Server.Kitchen.EntitySystems
         [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
         [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
         [Dependency] private readonly SharedDestructibleSystem _destructible = default!;
-        [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!; // Carpmosia - Insert storage contents into reagent grinder
+        [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
         [Dependency] private readonly RandomHelperSystem _randomHelper = default!;
         [Dependency] private readonly JitteringSystem _jitter = default!;
 
@@ -64,7 +64,7 @@ namespace Content.Server.Kitchen.EntitySystems
             SubscribeLocalEvent<ReagentGrinderComponent, ReagentGrinderStartMessage>(OnStartMessage);
             SubscribeLocalEvent<ReagentGrinderComponent, ReagentGrinderEjectChamberAllMessage>(OnEjectChamberAllMessage);
             SubscribeLocalEvent<ReagentGrinderComponent, ReagentGrinderEjectChamberContentMessage>(OnEjectChamberContentMessage);
-            SubscribeLocalEvent<ReagentGrinderComponent, ContainerDoAfterEvent>(OnContainerDoAfter); // Carpmosia - Insert storage contents into reagent grinder
+            SubscribeLocalEvent<ReagentGrinderComponent, ContainerDoAfterEvent>(OnContainerDoAfter);
         }
 
         private void OnToggleAutoModeMessage(Entity<ReagentGrinderComponent> entity, ref ReagentGrinderToggleAutoModeMessage message)
@@ -179,7 +179,6 @@ namespace Content.Server.Kitchen.EntitySystems
 
             if (!HasComp<ExtractableComponent>(heldEnt))
             {
-                // Carpmosia-start - Insert storage contents into reagent grinder
                 if (HasComp<StorageComponent>(heldEnt))
                 {
                     var doAfter = new DoAfterArgs(EntityManager, args.User, 0.5f, new ContainerDoAfterEvent(), entity, entity, used: heldEnt)
@@ -193,7 +192,6 @@ namespace Content.Server.Kitchen.EntitySystems
                 }
 
                 else if (!HasComp<FitsInDispenserComponent>(heldEnt))
-                // Carpmosia-end
                 {
                     // This is ugly but we can't use whitelistFailPopup because there are 2 containers with different whitelists.
                     _popupSystem.PopupEntity(Loc.GetString("reagent-grinder-component-cannot-put-entity-message"), entity.Owner, args.User);
@@ -292,7 +290,14 @@ namespace Content.Server.Kitchen.EntitySystems
                 UpdateUiState(entity);
             }
         }
-        // Carpmosia-start - Insert storage contents into reagent grinder
+
+        /// <summary>
+        /// DoAfter function for interacting with the grinder with an item with a storage component.
+        /// Moves any Extractable items from the storage of the held item to the grinder's container.
+        /// </summary>
+        /// <param name="uid">The grinder</param>
+        /// <param name="comp">The grinder component</param>
+        /// <param name="args">DoAfter args</param>
         private void OnContainerDoAfter(EntityUid uid, ReagentGrinderComponent comp, ContainerDoAfterEvent args)
         {
             // If there's no storage component, we leave
@@ -326,7 +331,6 @@ namespace Content.Server.Kitchen.EntitySystems
 
             args.Handled = true;
         }
-        // Carpmosia-end
 
         /// <summary>
         /// The wzhzhzh of the grinder. Processes the contents of the grinder and puts the output in the beaker.

--- a/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
@@ -64,7 +64,7 @@ namespace Content.Server.Kitchen.EntitySystems
             SubscribeLocalEvent<ReagentGrinderComponent, ReagentGrinderStartMessage>(OnStartMessage);
             SubscribeLocalEvent<ReagentGrinderComponent, ReagentGrinderEjectChamberAllMessage>(OnEjectChamberAllMessage);
             SubscribeLocalEvent<ReagentGrinderComponent, ReagentGrinderEjectChamberContentMessage>(OnEjectChamberContentMessage);
-            SubscribeLocalEvent<ReagentGrinderComponent, ContainerDoAfterEvent>(OnContainerDoAfter); // Carpmosia - Insert storage contents into reagent grinder
+            SubscribeLocalEvent<ReagentGrinderComponent, ContainerDoAfterEvent>(OnContainerDoAfter); // Carpmosia-edit - Insert storage contents into reagent grinder
         }
 
         private void OnToggleAutoModeMessage(Entity<ReagentGrinderComponent> entity, ref ReagentGrinderToggleAutoModeMessage message)
@@ -193,7 +193,7 @@ namespace Content.Server.Kitchen.EntitySystems
                 }
 
                 else if (!HasComp<FitsInDispenserComponent>(heldEnt))
-                // Carpmosia-end
+                // Carpmosia-end - Insert storage contents into reagent grinder
                 {
                     // This is ugly but we can't use whitelistFailPopup because there are 2 containers with different whitelists.
                     _popupSystem.PopupEntity(Loc.GetString("reagent-grinder-component-cannot-put-entity-message"), entity.Owner, args.User);

--- a/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
@@ -6,7 +6,7 @@ using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Destructible;
-using Content.Shared.DoAfter; // Carpmosia - Insert storage contents into reagent grinder
+using Content.Shared.DoAfter; // Carpmosia-edit - Insert storage contents into reagent grinder
 using Content.Shared.FixedPoint;
 using Content.Shared.Interaction;
 using Content.Shared.Kitchen;
@@ -25,7 +25,7 @@ using Content.Server.Construction.Completions;
 using Content.Server.Jittering;
 using Content.Shared.Jittering;
 using Content.Shared.Power;
-using Content.Shared.Storage; // Carpmosia - Insert storage contents into reagent grinder
+using Content.Shared.Storage; // Carpmosia-edit - Insert storage contents into reagent grinder
 
 namespace Content.Server.Kitchen.EntitySystems
 {
@@ -42,7 +42,7 @@ namespace Content.Server.Kitchen.EntitySystems
         [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
         [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
         [Dependency] private readonly SharedDestructibleSystem _destructible = default!;
-        [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!; // Carpmosia - Insert storage contents into reagent grinder
+        [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!; // Carpmosia-edit - Insert storage contents into reagent grinder
         [Dependency] private readonly RandomHelperSystem _randomHelper = default!;
         [Dependency] private readonly JitteringSystem _jitter = default!;
 

--- a/Content.Shared/_Carpmosia/Kitchen/Events/ContainerDoAfterEvent.cs
+++ b/Content.Shared/_Carpmosia/Kitchen/Events/ContainerDoAfterEvent.cs
@@ -1,0 +1,6 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Kitchen;
+[Serializable, NetSerializable]
+public sealed partial class ContainerDoAfterEvent : SimpleDoAfterEvent { }

--- a/Resources/Locale/en-US/_Carpmosia/kitchen/components/reagent-grinder-component.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/kitchen/components/reagent-grinder-component.ftl
@@ -1,0 +1,3 @@
+## UI
+
+reagent-grinder-component-storage-full-message = The grinder is full.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
A recreation (daresay improvement?) of a change I've implemented previously. Lets you insert the contents of a held bag directly into a reagent grinder.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Its a nice convenience feature that makes cooperation between botany and chemistry much less painful (and grinding plants in general a much nicer experience).
## Technical details
Adds to the existing OnInteractUsing function in ReagentGrinderSystem. If you are holding something with a storage component, a doafter will start, after which anything inside the storage that has the Extractable component will be added to the storage of the grinder (respecting the maximum capacity of the reagent grinder).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/0e469a5f-cb9e-4b3f-a2ce-ebb766ef6d14


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None that I am aware of.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: You may now dump the contents of a bag directly into a reagent grinder.
