### PR TITLE
Chemmaster and reagent dispenser transfer tweaks

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -2,7 +2,7 @@
                 xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                 xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-                MinSize="620 670"
+                MinSize="670 670"
                 Title="{Loc 'chem-master-bound-user-interface-title'}">
     <TabContainer Name="Tabs" Margin="5 5 7 5">
         <BoxContainer Orientation="Vertical" HorizontalExpand="True" Margin="5" SeparationOverride="10">

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -1,10 +1,12 @@
+<!-- Carpmosia-start - reagentTransfer -->
 <controls:FancyWindow xmlns="https://spacestation14.io"
                 xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                 xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-                MinSize="620 670"
+                MinSize="670 670"
                 Title="{Loc 'chem-master-bound-user-interface-title'}">
-    <TabContainer Name="Tabs" Margin="5 5 7 5">
+<!-- Carpmosia-end - reagentTransfer -->
+    <TabContainer Name="Tabs" Margin="5 5 7 5"> 
         <BoxContainer Orientation="Vertical" HorizontalExpand="True" Margin="5" SeparationOverride="10">
             <!-- Input container info -->
             <BoxContainer Orientation="Horizontal">

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -118,10 +118,12 @@ namespace Content.Client.Chemistry.UI
                 ("10", ChemMasterReagentAmount.U10, StyleBase.ButtonOpenBoth),
                 ("15", ChemMasterReagentAmount.U15, StyleBase.ButtonOpenBoth),
                 ("20", ChemMasterReagentAmount.U20, StyleBase.ButtonOpenBoth),
-                ("25", ChemMasterReagentAmount.U25, StyleBase.ButtonOpenBoth),
+                // Carpmosia-start - reagentStorage&TransferMK2
                 ("30", ChemMasterReagentAmount.U30, StyleBase.ButtonOpenBoth),
-                ("50", ChemMasterReagentAmount.U50, StyleBase.ButtonOpenBoth),
-                ("100", ChemMasterReagentAmount.U100, StyleBase.ButtonOpenBoth),
+                ("40", ChemMasterReagentAmount.U40, StyleBase.ButtonOpenBoth),
+                ("60", ChemMasterReagentAmount.U60, StyleBase.ButtonOpenBoth),
+                ("120", ChemMasterReagentAmount.U120, StyleBase.ButtonOpenBoth),
+                // Carpmosia-end - reagentStorage&TransferMK2
                 (Loc.GetString("chem-master-window-buffer-all-amount"), ChemMasterReagentAmount.All, StyleBase.ButtonOpenLeft),
             };
 

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -118,12 +118,13 @@ namespace Content.Client.Chemistry.UI
                 ("10", ChemMasterReagentAmount.U10, StyleBase.ButtonOpenBoth),
                 ("15", ChemMasterReagentAmount.U15, StyleBase.ButtonOpenBoth),
                 ("20", ChemMasterReagentAmount.U20, StyleBase.ButtonOpenBoth),
-                // Carpmosia-start - reagentTransfer
+                ("25", ChemMasterReagentAmount.U25, StyleBase.ButtonOpenBoth),
                 ("30", ChemMasterReagentAmount.U30, StyleBase.ButtonOpenBoth),
-                ("40", ChemMasterReagentAmount.U40, StyleBase.ButtonOpenBoth),
-                ("60", ChemMasterReagentAmount.U60, StyleBase.ButtonOpenBoth),
-                ("120", ChemMasterReagentAmount.U120, StyleBase.ButtonOpenBoth),
-                // Carpmosia-end - reagentTransfer
+                ("40", ChemMasterReagentAmount.U40, StyleBase.ButtonOpenBoth), // Carpmosia-edit - reagentTransfer
+                ("50", ChemMasterReagentAmount.U50, StyleBase.ButtonOpenBoth),
+                ("60", ChemMasterReagentAmount.U60, StyleBase.ButtonOpenBoth), // Carpmosia-edit - reagentTransfer
+                ("100", ChemMasterReagentAmount.U100, StyleBase.ButtonOpenBoth),
+                ("120", ChemMasterReagentAmount.U120, StyleBase.ButtonOpenBoth), // Carpmosia-edit - reagentTransfer
                 (Loc.GetString("chem-master-window-buffer-all-amount"), ChemMasterReagentAmount.All, StyleBase.ButtonOpenLeft),
             };
 

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -118,12 +118,12 @@ namespace Content.Client.Chemistry.UI
                 ("10", ChemMasterReagentAmount.U10, StyleBase.ButtonOpenBoth),
                 ("15", ChemMasterReagentAmount.U15, StyleBase.ButtonOpenBoth),
                 ("20", ChemMasterReagentAmount.U20, StyleBase.ButtonOpenBoth),
-                // Carpmosia-start - reagentStorage&TransferMK2
+                // Carpmosia-start - reagentTransfer
                 ("30", ChemMasterReagentAmount.U30, StyleBase.ButtonOpenBoth),
                 ("40", ChemMasterReagentAmount.U40, StyleBase.ButtonOpenBoth),
                 ("60", ChemMasterReagentAmount.U60, StyleBase.ButtonOpenBoth),
                 ("120", ChemMasterReagentAmount.U120, StyleBase.ButtonOpenBoth),
-                // Carpmosia-end - reagentStorage&TransferMK2
+                // Carpmosia-end - reagentTransfer
                 (Loc.GetString("chem-master-window-buffer-all-amount"), ChemMasterReagentAmount.All, StyleBase.ButtonOpenLeft),
             };
 

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
@@ -9,14 +9,16 @@
     <BoxContainer Orientation="Horizontal">
         <BoxContainer Orientation="Vertical" MinWidth="170">
             <Label Text="{Loc 'reagent-dispenser-window-amount-to-dispense-label'}" HorizontalAlignment="Center" />
+            <!-- Carpmosia-start - reagentStorage&TransferMK2 -->
             <ui:ButtonGrid
                 Name="AmountGrid"
                 Access="Public"
                 Columns="3"
                 HorizontalAlignment="Center"
                 Margin="5"
-                ButtonList="1,5,10,15,20,25,30,50,100"
+                ButtonList="1,5,10,15,20,30,40,60,120"
                 RadioGroup="True">
+            <!-- Carpmosia-end - reagentStorage&TransferMK2 -->
             </ui:ButtonGrid>
             <Control VerticalExpand="True" />
             <Label Name="ContainerInfoName"

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
@@ -9,7 +9,7 @@
     <BoxContainer Orientation="Horizontal">
         <BoxContainer Orientation="Vertical" MinWidth="170">
             <Label Text="{Loc 'reagent-dispenser-window-amount-to-dispense-label'}" HorizontalAlignment="Center" />
-            <!-- Carpmosia-start - reagentStorage&TransferMK2 -->
+            <!-- Carpmosia-start - reagentTransfer -->
             <ui:ButtonGrid
                 Name="AmountGrid"
                 Access="Public"
@@ -18,7 +18,7 @@
                 Margin="5"
                 ButtonList="1,5,10,15,20,30,40,60,120"
                 RadioGroup="True">
-            <!-- Carpmosia-end - reagentStorage&TransferMK2 -->
+            <!-- Carpmosia-end - reagentTransfer -->
             </ui:ButtonGrid>
             <Control VerticalExpand="True" />
             <Label Name="ContainerInfoName"

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
@@ -16,7 +16,7 @@
                 Columns="3"
                 HorizontalAlignment="Center"
                 Margin="5"
-                ButtonList="1,5,10,15,20,30,40,60,120"
+                ButtonList="1,5,10,15,20,25,30,40,50,60,100,120"
                 RadioGroup="True">
             <!-- Carpmosia-end - reagentTransfer -->
             </ui:ButtonGrid>

--- a/Content.Shared/Chemistry/SharedChemMaster.cs
+++ b/Content.Shared/Chemistry/SharedChemMaster.cs
@@ -108,12 +108,13 @@ namespace Content.Shared.Chemistry
         U10 = 10,
         U15 = 15,
         U20 = 20,
-        // Carpmosia-start - reagentTransfer
+        U25 = 25,
         U30 = 30,
-        U40 = 40,
-        U60 = 60,
-        U120 = 120,
-        // Carpmosia-end - reagentTransfer
+        U40 = 40, // Carpmosia-edit - reagentTransfer
+        U50 = 50,
+        U60 = 60, // Carpmosia-edit - reagentTransfer
+        U100 = 100,
+        U120 = 120, // Carpmosia-edit - reagentTransfer
         All,
     }
 

--- a/Content.Shared/Chemistry/SharedChemMaster.cs
+++ b/Content.Shared/Chemistry/SharedChemMaster.cs
@@ -108,10 +108,12 @@ namespace Content.Shared.Chemistry
         U10 = 10,
         U15 = 15,
         U20 = 20,
-        U25 = 25,
+        // Carpmosia-start - reagentStorage&TransferMK2
         U30 = 30,
-        U50 = 50,
-        U100 = 100,
+        U40 = 40,
+        U60 = 60,
+        U120 = 120,
+        // Carpmosia-end - reagentStorage&TransferMK2
         All,
     }
 

--- a/Content.Shared/Chemistry/SharedChemMaster.cs
+++ b/Content.Shared/Chemistry/SharedChemMaster.cs
@@ -108,12 +108,12 @@ namespace Content.Shared.Chemistry
         U10 = 10,
         U15 = 15,
         U20 = 20,
-        // Carpmosia-start - reagentStorage&TransferMK2
+        // Carpmosia-start - reagentTransfer
         U30 = 30,
         U40 = 40,
         U60 = 60,
         U120 = 120,
-        // Carpmosia-end - reagentStorage&TransferMK2
+        // Carpmosia-end - reagentTransfer
         All,
     }
 

--- a/Content.Shared/Chemistry/SharedReagentDispenser.cs
+++ b/Content.Shared/Chemistry/SharedReagentDispenser.cs
@@ -46,15 +46,24 @@ namespace Content.Shared.Chemistry
                 case "20":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U20;
                     break;
-                // Carpmosia-start - reagentTransfer
+                case "25":
+                    ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U25;
+                    break;
                 case "30":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U30;
                     break;
+                // Carpmosia-start - reagentTransfer
                 case "40":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U40;
                     break;
+                case "50":
+                    ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U50;
+                    break;
                 case "60":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U60;
+                    break;
+                case "100":
+                    ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U100;
                     break;
                 case "120":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U120;
@@ -104,12 +113,13 @@ namespace Content.Shared.Chemistry
         U10 = 10,
         U15 = 15,
         U20 = 20,
-        // Carpmosia-start - reagentTransfer
+        U25 = 25,
         U30 = 30,
-        U40 = 40,
-        U60 = 60,
-        U120 = 120,
-        // Carpmosia-end - reagentTransfer
+        U40 = 40, // Carpmosia-edit - reagentTransfer
+        U50 = 50,
+        U60 = 60, // Carpmosia-edit - reagentTransfer
+        U100 = 100,
+        U120 = 120, // Carpmosia-edit - reagentTransfer
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Chemistry/SharedReagentDispenser.cs
+++ b/Content.Shared/Chemistry/SharedReagentDispenser.cs
@@ -46,18 +46,20 @@ namespace Content.Shared.Chemistry
                 case "20":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U20;
                     break;
-                case "25":
-                    ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U25;
-                    break;
+                // Carpmosia-start - reagentStorage&TransferMK2
                 case "30":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U30;
                     break;
-                case "50":
-                    ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U50;
+                case "40":
+                    ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U40;
                     break;
-                case "100":
-                    ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U100;
+                case "60":
+                    ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U60;
                     break;
+                case "120":
+                    ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U120;
+                    break;
+                // Carpmosia-end - reagentStorage&TransferMK2
                 default:
                     throw new Exception($"Cannot convert the string `{s}` into a valid ReagentDispenser DispenseAmount");
             }
@@ -102,10 +104,12 @@ namespace Content.Shared.Chemistry
         U10 = 10,
         U15 = 15,
         U20 = 20,
-        U25 = 25,
+        // Carpmosia-start - reagentStorage&TransferMK2
         U30 = 30,
-        U50 = 50,
-        U100 = 100,
+        U40 = 40,
+        U60 = 60,
+        U120 = 120,
+        // Carpmosia-end - reagentStorage&TransferMK2
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Chemistry/SharedReagentDispenser.cs
+++ b/Content.Shared/Chemistry/SharedReagentDispenser.cs
@@ -46,7 +46,7 @@ namespace Content.Shared.Chemistry
                 case "20":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U20;
                     break;
-                // Carpmosia-start - reagentStorage&TransferMK2
+                // Carpmosia-start - reagentTransfer
                 case "30":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U30;
                     break;
@@ -59,7 +59,7 @@ namespace Content.Shared.Chemistry
                 case "120":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U120;
                     break;
-                // Carpmosia-end - reagentStorage&TransferMK2
+                // Carpmosia-end - reagentTransfer
                 default:
                     throw new Exception($"Cannot convert the string `{s}` into a valid ReagentDispenser DispenseAmount");
             }
@@ -104,12 +104,12 @@ namespace Content.Shared.Chemistry
         U10 = 10,
         U15 = 15,
         U20 = 20,
-        // Carpmosia-start - reagentStorage&TransferMK2
+        // Carpmosia-start - reagentTransfer
         U30 = 30,
         U40 = 40,
         U60 = 60,
         U120 = 120,
-        // Carpmosia-end - reagentStorage&TransferMK2
+        // Carpmosia-end - reagentTransfer
     }
 
     [Serializable, NetSerializable]


### PR DESCRIPTION
## About the PR
Made for #14, Adds new buttons to the chemmaster and reagent dispensers (chemical, booze, soda) that better fit the new sizes of beakers and shakers.

## Why / Balance
Quality of life change that allows for slightly easier mixing for the most part.

## Technical details
Added button amounts 40, 60, 120 in all relevant files, and made the chemmaster window slightly wider so it does not start with a scroll bar

## Media
<img width="797" height="496" alt="Screenshot 2025-10-18 065153" src="https://github.com/user-attachments/assets/d074a437-1e53-485c-9486-499ad79edc17" />
<img width="671" height="668" alt="Screenshot 2025-10-18 065213" src="https://github.com/user-attachments/assets/8cda926e-5f07-41f9-b899-fa028ace77da" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Three new transfer amounts (40, 60, and 120) have been added to the chemmaster and reagent dispensers to reflect the increased sizes of beakers and shakers.
