### PR TITLE
Added Maids

### DIFF
--- a/Resources/Prototypes/_Carpmosia/Loadouts/Groups/Civilian/janitor.yml
+++ b/Resources/Prototypes/_Carpmosia/Loadouts/Groups/Civilian/janitor.yml
@@ -30,6 +30,7 @@
   loadouts:
   - JanitorJumpsuit
   - JanitorJumpskirt
+  - JanitorMaidskirt
 
 - type: loadoutGroup
   id: JanitorBackpack

--- a/Resources/Prototypes/_Carpmosia/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/_Carpmosia/Loadouts/Jobs/Civilian/janitor.yml
@@ -1,9 +1,18 @@
+- type: loadoutEffectGroup
+  id: CompetentJanitorial
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobJanitor
+      time: 20h # let's say you get how janitor works after 10-15 shifts
+
 # Jumpsuit
 #  carpmosia maid jani
 - type: loadout
   id: JanitorMaidskirt
   effects:
   - !type:GroupLoadoutEffect
-    proto: SeniorJanitorial
+    proto: CompetentJanitorial
   equipment:
     jumpsuit: ClothingUniformJumpskirtJanimaid

--- a/Resources/Prototypes/_Carpmosia/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/_Carpmosia/Loadouts/Jobs/Civilian/janitor.yml
@@ -1,0 +1,9 @@
+# Jumpsuit
+#  carpmosia maid jani
+- type: loadout
+  id: JanitorMaidskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SeniorJanitorial
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtJanimaid


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the Janitorial Maid JumpSkirt to the Janitor Loadout menu, locked behind the Senior Janitor playtime requirement

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Janitors can be maid too, if they deserve

## Technical details
<!-- Summary of code changes for easier review. -->
Millions must YMLslop

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="715" height="340" alt="obraz" src="https://github.com/user-attachments/assets/f73f0ee2-653e-48f8-9a4b-ea9a6e470db7" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: korczoczek
- add: Deserving Janitors can now choose the Maid Uniform as their loadout Jumpsuit

