### PR TITLE
Give paramedics & CMO external access 

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -28,7 +28,7 @@
   - ChiefMedicalOfficer
   - Brig
   - Cryogenics
-  - External # Carpmosia edit - external paramedics
+  - External # Carpmosia-edit - external paramedics
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -28,6 +28,7 @@
   - ChiefMedicalOfficer
   - Brig
   - Cryogenics
+  - External # Carpmosia edit - external paramedics
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -13,6 +13,7 @@
   access:
   - Medical
   - Maintenance
+  - External
   extendedAccess:
   - Chemistry
 

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -13,7 +13,7 @@
   access:
   - Medical
   - Maintenance
-  - External
+  - External # Carpmosia edit - external paramedics
   extendedAccess:
   - Chemistry
 

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -13,7 +13,7 @@
   access:
   - Medical
   - Maintenance
-  - External # Carpmosia edit - external paramedics
+  - External # Carpmosia-edit - external paramedics
   extendedAccess:
   - Chemistry
 


### PR DESCRIPTION
## About the PR
~~Engage in the upstream ouroborean cycle~~ Give paramedics & the CMO roundstart external ID access flags.

## Why / Balance
Paramedics need to retrieve bodies from space sometimes. CMO needs to promote paramedics sometimes.

## Technical details
yaml warrior and what's worse this one's a webedit :fearful

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Antag is unplayable now :-1:

**Changelog**
:cl:
- tweak: Paramedics now start with external access on their ID card.