### PR TITLE
Make glasstles and steel-cap logs recyclable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -227,6 +227,9 @@
   - type: Log
     spawnedPrototype: SheetSteel1
     spawnCount: 1
+  - type: PhysicalComposition # Carpmosia-edit - recyclable produce
+    materialComposition:
+      Steel: 100
 
 - type: entity
   name: nettle
@@ -1812,6 +1815,9 @@
   - type: ToolRefinable
     refineResult:
     - id: SheetGlass1
+  - type: PhysicalComposition # Carpmosia-edit - recyclable produce
+    materialComposition:
+      Glass: 100
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -227,9 +227,11 @@
   - type: Log
     spawnedPrototype: SheetSteel1
     spawnCount: 1
-  - type: PhysicalComposition # Carpmosia-edit - recyclable produce
+  # Carpmosia-start - recyclable produce
+  - type: PhysicalComposition
     materialComposition:
       Steel: 100
+  # Carpmosia-end - recyclable produce
 
 - type: entity
   name: nettle
@@ -1815,9 +1817,11 @@
   - type: ToolRefinable
     refineResult:
     - id: SheetGlass1
-  - type: PhysicalComposition # Carpmosia-edit - recyclable produce
+  # Carpmosia-start - recyclable produce
+  - type: PhysicalComposition
     materialComposition:
       Glass: 100
+  # Carpmosia-end - recyclable produce
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
## About the PR
Makes steel-cap logs and glasstles turn into steel and glass when ran through a recycler.

## Why / Balance
Botany players kept asking me to do this.

## Technical details
Adds PhysicalCompositionComponent to the produce items.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Botany too good :-1:

**Changelog**
:cl:
- add: Glasstles and steel-cap logs can now also be turned into material sheets with a recycler.