### PR TITLE
Wizard Smite Rework

### DIFF
--- a/Content.Shared/Magic/SharedMagicSystem.cs
+++ b/Content.Shared/Magic/SharedMagicSystem.cs
@@ -4,8 +4,10 @@ using Content.Shared.Body.Systems;
 using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
 using Content.Shared.Coordinates.Helpers;
+using Content.Shared.Damage; // Carpmosia-edit - Wizard Smite Rework
 using Content.Shared.Doors.Components;
 using Content.Shared.Doors.Systems;
+using Content.Shared.FixedPoint; // Carpmosia-edit - Wizard Smite Rework
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
@@ -15,6 +17,8 @@ using Content.Shared.Magic.Components;
 using Content.Shared.Magic.Events;
 using Content.Shared.Maps;
 using Content.Shared.Mind;
+using Content.Shared.Mobs.Components; // Carpmosia-edit - Wizard Smite Rework
+using Content.Shared.Mobs.Systems; // Carpmosia-edit - Wizard Smite Rework
 using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Speech.Muting;
@@ -66,6 +70,9 @@ public abstract class SharedMagicSystem : EntitySystem
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly TurfSystem _turf = default!;
     [Dependency] private readonly SharedChargesSystem _charges = default!;
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!; // Carpmosia-edit - Wizard Smite Rework
+    [Dependency] private readonly MobStateSystem _mobStateSystem = default!; // Carpmosia-edit - Wizard Smite Rework
+    [Dependency] private readonly MobThresholdSystem _mobThresholdSystem = default!; // Carpmosia-edit - Wizard Smite Rework
 
     private static readonly ProtoId<TagPrototype> InvalidForGlobalSpawnSpellTag = "InvalidForGlobalSpawnSpell";
 
@@ -80,6 +87,7 @@ public abstract class SharedMagicSystem : EntitySystem
         SubscribeLocalEvent<ProjectileSpellEvent>(OnProjectileSpell);
         SubscribeLocalEvent<ChangeComponentsSpellEvent>(OnChangeComponentsSpell);
         SubscribeLocalEvent<SmiteSpellEvent>(OnSmiteSpell);
+        SubscribeLocalEvent<DamageSmiteSpellEvent>(OnDamageSmiteSpell); // Carpmosia-edit - Wizard Smite Rework
         SubscribeLocalEvent<KnockSpellEvent>(OnKnockSpell);
         SubscribeLocalEvent<ChargeSpellEvent>(OnChargeSpell);
         SubscribeLocalEvent<RandomGlobalSpawnSpellEvent>(OnRandomGlobalSpawnSpell);
@@ -394,6 +402,33 @@ public abstract class SharedMagicSystem : EntitySystem
 
         _body.GibBody(ev.Target, true, body);
     }
+    // Carpmosia-start - Wizard Smite Rework
+    private void OnDamageSmiteSpell(DamageSmiteSpellEvent ev)
+    {
+        FixedPoint2 dealtDamage = ev.Damage;
+        DamageSpecifier dspec = new DamageSpecifier();
+
+        if (HasComp<MobStateComponent>(ev.Target))
+        {
+            // Prevent use on dead and critical targets
+            if (_mobStateSystem.IsCritical(ev.Target) || _mobStateSystem.IsDead(ev.Target))
+                return;
+        }
+        if (TryComp<DamageableComponent>(ev.Target, out var damageable) && TryComp<MobThresholdsComponent>(ev.Target, out var thresholds))
+        {
+            if (_mobThresholdSystem.TryGetIncapThreshold(ev.Target, out var threshold, thresholds))
+                dealtDamage = (FixedPoint2)threshold - damageable.TotalDamage;
+        }
+
+        if (ev.Handled || !PassesSpellPrerequisites(ev.Action, ev.Performer))
+            return;
+
+        ev.Handled = true;
+
+        dspec.DamageDict.Add(ev.DamageType, dealtDamage);
+        _damageableSystem.TryChangeDamage(ev.Target, dspec, true);
+    }
+    // Carpmosia-end - Wizard Smite Rework
 
     // End Touch Spells
     #endregion

--- a/Content.Shared/_Carpmosia/Magic/Events/DamageSmiteSpellEvent.cs
+++ b/Content.Shared/_Carpmosia/Magic/Events/DamageSmiteSpellEvent.cs
@@ -1,0 +1,18 @@
+using Content.Shared.Actions;
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.Magic.Events;
+
+public sealed partial class DamageSmiteSpellEvent : EntityTargetActionEvent
+{
+    /// <summary>
+    /// Damage dealt by default in case we fail to find the threshold
+    /// </summary>
+    public FixedPoint2 Damage = 100;
+
+    /// <summary>
+    /// Damage type dealt by the spell
+    /// </summary>
+    [DataField("damageType")]
+    public string DamageType { get; set; } = "Cellular";
+}

--- a/Resources/Locale/en-US/_Carpmosia/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/store/spellbook-catalog.ftl
@@ -1,0 +1,1 @@
+spellbook-alt-smite-desc = Don't like them? SMITE them! Requires Wizard Robe & Hat.

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -29,7 +29,7 @@
 - type: listing
   id: SpellbookSmite
   name: spellbook-smite-name
-  description: spellbook-smite-desc
+  description: spellbook-alt-smite-desc # Carpmosia-edit - Wizard Smite Rework
   productAction: ActionSmite
   cost:
     WizCoin: 3

--- a/Resources/Prototypes/Magic/touch_spells.yml
+++ b/Resources/Prototypes/Magic/touch_spells.yml
@@ -36,7 +36,7 @@
       sprite: Objects/Magic/magicactions.rsi
       state: gib
   - type: EntityTargetAction
-    event: !type:SmiteSpellEvent
+    event: !type:DamageSmiteSpellEvent # Carpmosia-edit - Wizard Smite Rework
   - type: SpeakOnAction
     sentence: action-speech-spell-smite
   - type: Magic


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changes Wizard smite to deal the exact amount of damage (in cellular) needed to put a target in crit using a new event instead of instagibbing the target.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Wizard has a lot of things that make it overbearing and feels-bad. This is one of those things. The spell should still be pretty strong, and dealing cellular does mean that the target will probably be out of commission for a bit, but at least they have a chance to come back now.
## Technical details
<!-- Summary of code changes for easier review. -->
Wrote a new spell event to handle the smite spell. Changed the smite prototype to use the new spell event. Updated the description of Smite to reflect what it does now.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 

https://github.com/user-attachments/assets/6cda3e21-b047-4305-9626-d82a953d91f7

Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Wizard Smite now puts the target in critical condition rather than gibbing the target.

