### PR TITLE
Add the yellow apron to janitor loadout and vendor

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
@@ -9,6 +9,7 @@
     ClothingBeltJanitor: 2
     ClothingHeadsetService: 2
     ClothingOuterWinterJani: 2
+    ClothingOuterApron: 2 # Carpmosia-edit - janitor aprons
     ClothingNeckScarfStripedPurple: 3
   contrabandInventory:
     ToyFigurineJanitor: 1

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -2,7 +2,7 @@
   parent: ClothingOuterStorageBase
   id: ClothingOuterApron
   name: apron
-  description: A fancy apron for a stylish person.
+  description: A neat apron for cleaning spills and litter. # Caprmosia-edit - janitor aprons
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Misc/apron.rsi

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -46,6 +46,13 @@
   equipment:
     outerClothing: ClothingOuterWinterJani
 
+# Carpmosia-start - janitor aprons
+- type: loadout
+  id: JanitorApron
+  equipment:
+    outerClothing: ClothingOuterApron
+# Carpmosia-end - janitor aprons
+
 # Misc
 - type: loadout
   id: JanitorGoldenPlunger

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/janitor.yml
@@ -46,13 +46,6 @@
   equipment:
     outerClothing: ClothingOuterWinterJani
 
-# Carpmosia-start - janitor aprons
-- type: loadout
-  id: JanitorApron
-  equipment:
-    outerClothing: ClothingOuterApron
-# Carpmosia-end - janitor aprons
-
 # Misc
 - type: loadout
   id: JanitorGoldenPlunger

--- a/Resources/Prototypes/_Carpmosia/Loadouts/Groups/Civilian/janitor.yml
+++ b/Resources/Prototypes/_Carpmosia/Loadouts/Groups/Civilian/janitor.yml
@@ -49,6 +49,7 @@
   parent: [BaseOuterClothing, CommonOuterClothing, CivilianOuterClothing]
   loadouts:
   - JanitorWintercoat
+  - JanitorApron
 
 # - type: loadoutGroup
 #   id: JanitorShoes

--- a/Resources/Prototypes/_Carpmosia/Loadouts/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/_Carpmosia/Loadouts/Jobs/Civilian/janitor.yml
@@ -16,3 +16,9 @@
     proto: CompetentJanitorial
   equipment:
     jumpsuit: ClothingUniformJumpskirtJanimaid
+
+- type: loadout
+  id: JanitorApron
+  equipment:
+    outerClothing: ClothingOuterApron
+


### PR DESCRIPTION
## About the PR
Edits the description for ClothingOuterApron, adds it to the janitor loadout menu, and adds it to the janidrobe inventory.

## Why / Balance
The yellow apron is currently unobtainable outside of being mapped, and a person asked for this change on the forums.

## Technical details
tak tak tak tak tak tak i write the yml

## Media
<img width="334" height="557" alt="image" src="https://github.com/user-attachments/assets/e596e56d-4be9-4ee3-86d1-481e0e8cb911" />
<img width="1252" height="877" alt="image" src="https://github.com/user-attachments/assets/b1f34a22-472a-4172-aeec-806e59062944" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Janitors may now start with the yellow apron, or dispense it from the JaniDrobe.