### PR TITLE
Let the atmos fireaxe pry hull plating

### DIFF
--- a/Resources/Locale/en-US/_Carpmosia/tools/tool-qualities.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/tools/tool-qualities.ftl
@@ -1,0 +1,2 @@
+tool-quality-axing-name = Axing
+tool-quality-axing-tool-name = Fireaxe

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -77,4 +77,3 @@
     qualities:
       - Prying
   # Carpmosia-end - Plating axing
-

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -39,9 +39,11 @@
     slots:
     - back
   - type: Tool
-    speedModifier: 0.4 # Carpmosia-edit - Plating axing
+    # Carpmosia-start - Plating axing
+    speedModifier: 0.4
     useSound:
       path: /Audio/Items/crowbar.ogg
+    # Carpmosia-end - Plating axing
     qualities:
       - Prying
       - Axing # Carpmosia-edit - Plating axing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -39,6 +39,9 @@
     slots:
     - back
   - type: Tool
+    speedModifier: 0.4 # Carpmosia-edit - Plating axing
+    useSound:
+      path: /Audio/Items/crowbar.ogg
     qualities:
       - Prying
       - Axing # Carpmosia-edit - Plating axing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -41,6 +41,7 @@
   - type: Tool
     qualities:
       - Prying
+      - Axing # Carpmosia-edit - Plating axing
   - type: ToolTileCompatible
   - type: Prying
   - type: UseDelay

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -69,3 +69,9 @@
     quickEquip: false
     slots:
     - back
+  # Carpmosia-start - Plating axing
+  - type: Tool
+    qualities:
+      - Prying
+  # Carpmosia-end - Plating axing
+

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -46,7 +46,7 @@
   baseTurf: Lattice
   isSubfloor: true
   deconstructTools: [ Axing ] # Carpmosia-edit - Plating axing
-  itemDrop: FloorTileItemBrassFilled
+  itemDrop: FloorTileItemBrassFilled # Carpmosia-edit - Plating axing
   footstepSounds:
     collection: FootstepPlating
   friction: 1.5

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -4,6 +4,7 @@
   sprite: /Textures/Tiles/plating.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ] # Carpmosia-edit - Plating axing
   footstepSounds:
     collection: FootstepPlating
   friction: 1.5
@@ -20,6 +21,7 @@
   - 1.0
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ] # Carpmosia-edit - Plating axing
   footstepSounds:
     collection: FootstepPlating
   friction: 1.5
@@ -31,6 +33,7 @@
   sprite: /Textures/Tiles/Asteroid/asteroid_plating.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ] # Carpmosia-edit - Plating axing
   footstepSounds:
     collection: FootstepPlating
   friction: 1.5
@@ -42,6 +45,8 @@
   sprite: /Textures/Tiles/Misc/clockwork/clockwork_floor.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ] # Carpmosia-edit - Plating axing
+  itemDrop: FloorTileItemBrassFilled
   footstepSounds:
     collection: FootstepPlating
   friction: 1.5
@@ -53,6 +58,7 @@
   sprite: /Textures/Tiles/snow_plating.png #Not in the snow planet RSI because it doesn't have any metadata. Should probably be moved to its own folder later.
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ] # Carpmosia-edit - Plating axing
   footstepSounds:
     collection: FootstepPlating
   friction: 0.75 #a little less then actual snow

--- a/Resources/Prototypes/_Carpmosia/tool_qualities.yml
+++ b/Resources/Prototypes/_Carpmosia/tool_qualities.yml
@@ -1,0 +1,6 @@
+- type: tool
+  id: Axing
+  name: tool-quality-axing-name
+  toolName: tool-quality-axing-tool-name
+  spawn: FireAxe
+  icon: { sprite: Objects/Weapons/Melee/fireaxe.rsi, state: icon }


### PR DESCRIPTION
## About the PR
Lets the crew fire axe remove hull plating in addition to floor tiles.

Ideally the fireaxe would also get a unique use sound but I can't source that.

## Why / Balance
This was a popular feature on ronstation with many requests to port it.
Gives atmospheric technicians & savvy command members another method of spacing areas for repairs & removing plating for atmospherics setups.

## Technical details
Adds a new tool quality, gives it to the fireaxe, and adds a deconstruction field to plating prototypes.

## Media
<img width="309" height="294" alt="tmp" src="https://github.com/user-attachments/assets/56b1d94a-6418-482a-9160-9df8a91e4990" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The fireaxe in the bridge & atmos wall cabinets can now pry hull plating.