### PR TITLE
Add lawyer headset and make lawyer stamp contraband

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
@@ -12,7 +12,7 @@
     ClothingUniformJumpsuitLawyerGood: 1
     ClothingUniformJumpskirtLawyerGood: 1
     ClothingShoesBootsLaceup: 2
-    ClothingHeadsetService: 2
+    ClothingHeadsetLawyer: 2 # Carpmosia-edit - Lawyer headset
     ClothingNeckLawyerbadge: 2
     BriefcaseBrown: 2
     BookSpaceLaw: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/lawdrobe.yml
@@ -12,7 +12,7 @@
     ClothingUniformJumpsuitLawyerGood: 1
     ClothingUniformJumpskirtLawyerGood: 1
     ClothingShoesBootsLaceup: 2
-    ClothingHeadsetLawyer: 2 # Carpmosia-edit - Lawyer headset
+    ClothingHeadsetLawyer: 2 # Carpmosia-edit - Lawyer headset and specific contraband level
     ClothingNeckLawyerbadge: 2
     BriefcaseBrown: 2
     BookSpaceLaw: 3

--- a/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
@@ -78,7 +78,7 @@
 
 - type: entity
   name: lawyer's rubber stamp
-  parent: RubberStampBase
+  parent: [RubberStampBase, BaseLawyerContraband] # Carpmosia-edit - Lawyer headset and specific contraband level
   id: RubberStampLawyer
   categories: [ DoNotMap ]
   components:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -20,7 +20,7 @@
   equipment:
     shoes: ClothingShoesBootsLaceup
     id: LawyerPDA
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset
   inhand:
     - BriefcaseBrownFilled
   storage:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/lawyer.yml
@@ -20,7 +20,7 @@
   equipment:
     shoes: ClothingShoesBootsLaceup
     id: LawyerPDA
-    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset
+    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset and specific contraband level
   inhand:
     - BriefcaseBrownFilled
   storage:

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -1120,7 +1120,7 @@
     neck: ClothingNeckLawyerbadge
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
-    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset
+    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset and specific contraband level
     pocket1: RubberStampLawyer
     pocket2: LuxuryPen
   inhand:
@@ -1135,7 +1135,7 @@
     neck: ClothingNeckLawyerbadge
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
-    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset
+    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset and specific contraband level
     pocket1: RubberStampLawyer
     pocket2: SmokingPipeFilledTobacco
   inhand:
@@ -1151,7 +1151,7 @@
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
     belt: ClothingBeltStorageWaistbag
-    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset
+    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset and specific contraband level
     pocket1: RubberStampLawyer
     pocket2: SmokingPipeFilledTobacco
   inhand:
@@ -1168,7 +1168,7 @@
     mask: CigarGold
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
-    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset
+    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset and specific contraband level
     outerClothing: ClothingOuterCoatExpensive
     pocket1: RubberStampLawyer
     pocket2: LuxuryPen
@@ -1185,7 +1185,7 @@
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
     belt: ClothingBeltStorageWaistbag
-    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset
+    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset and specific contraband level
     pocket1: RubberStampLawyer
     pocket2: LuxuryPen
   inhand:

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -1120,7 +1120,7 @@
     neck: ClothingNeckLawyerbadge
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset
     pocket1: RubberStampLawyer
     pocket2: LuxuryPen
   inhand:
@@ -1135,7 +1135,7 @@
     neck: ClothingNeckLawyerbadge
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset
     pocket1: RubberStampLawyer
     pocket2: SmokingPipeFilledTobacco
   inhand:
@@ -1151,7 +1151,7 @@
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
     belt: ClothingBeltStorageWaistbag
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset
     pocket1: RubberStampLawyer
     pocket2: SmokingPipeFilledTobacco
   inhand:
@@ -1168,7 +1168,7 @@
     mask: CigarGold
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset
     outerClothing: ClothingOuterCoatExpensive
     pocket1: RubberStampLawyer
     pocket2: LuxuryPen
@@ -1185,7 +1185,7 @@
     id: VisitorPDA
     back: ClothingBackpackSatchelLeather
     belt: ClothingBeltStorageWaistbag
-    ears: ClothingHeadsetSecurity
+    ears: ClothingHeadsetLawyer # Carpmosia-edit - Lawyer headset
     pocket1: RubberStampLawyer
     pocket2: LuxuryPen
   inhand:

--- a/Resources/Prototypes/_Carpmosia/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Clothing/Ears/headsets.yml
@@ -11,6 +11,6 @@
       - EncryptionKeyService
       - EncryptionKeyCommon
   - type: Sprite
-    sprite: Clothing/Ears/Headsets/security.rsi
+    sprite: Clothing/Ears/Headsets/servicesecurity.rsi
   - type: Clothing
-    sprite: Clothing/Ears/Headsets/security.rsi
+    sprite: Clothing/Ears/Headsets/servicesecurity.rsi

--- a/Resources/Prototypes/_Carpmosia/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Clothing/Ears/headsets.yml
@@ -1,0 +1,16 @@
+- type: entity
+  parent: [ClothingHeadset, BaseLawyerContraband]
+  id: ClothingHeadsetLawyer
+  name: lawyer headset
+  description: To keep in the know about current legal cases and domestic issues.
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeySecurity
+      - EncryptionKeyService
+      - EncryptionKeyCommon
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/security.rsi
+  - type: Clothing
+    sprite: Clothing/Ears/Headsets/security.rsi

--- a/Resources/Prototypes/_Carpmosia/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Objects/base_contraband.yml
@@ -1,0 +1,7 @@
+- type: entity
+  id: BaseLawyerContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedJobs: [ Lawyer ]


### PR DESCRIPTION
## About the PR
Added a lawyer headset with a security, service, and common key, marked as lawyer only contraband, and marked lawyer stamp the same way.

## Why / Balance
Lawyers are civilian and have access to service comms from the lawdrobe, but start with only sec comms. Taken from cr0w_alt_f4's suggestion on discord.
Stamp was given the contraband level as it should not be allowed for anyone to carry and the level was already added by this PR.

## Technical details
Added ClothingHeadsetLawyer with security, service, and common keys, modified relevant preset equipment to use new headset. Uses the currently unused sevicesecurity sprite.
Added BaseLawyerContraband to mark the lawyer headset and lawyer stamp as lawyer only.

## Media
<img width="628" height="298" alt="Screenshot 2025-10-28 093545" src="https://github.com/user-attachments/assets/ec629807-5f39-4387-b791-782d357809f3" />
<img width="344" height="150" alt="Screenshot 2025-10-28 093634" src="https://github.com/user-attachments/assets/1b84b3ee-7888-483d-9f30-f6db0bc594ab" />
<img width="578" height="146" alt="Screenshot 2025-10-28 085202" src="https://github.com/user-attachments/assets/679dbab0-1c7f-4c9c-aab8-a1042e59f86f" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added a unique headset for lawyers.
- tweak: Lawyer stamp is now lawyer contraband.
