### PR TITLE
Make N2O and frezon more valuable

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -86,7 +86,7 @@
   molarMass: 44
   color: 8F00FF
   reagent: NitrousOxide
-  pricePerMole: 0.1
+  pricePerMole: 1 # Carpmosia-edit - More valuable gasses
 
 - type: gas
   id: 8
@@ -99,4 +99,4 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 1
+  pricePerMole: 4 # Carpmosia-edit - More valuable gasses


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made nitrous oxide and frezon more valuable. More precisely, nitrous oxide went from 0.1 price per mole to 1, and frezon, from 1 to 4.
This can also be read as N2O being 10 times more valuable now, and frezon is 4 times more valuable.

## Why / Balance
In practice, a canister full of N2O doesn't have a too great price for the effort to fill a canister up, but, it will offer some cash now.
A canister full of frezon, however, has way more value now, and thus, it incentivizes atmospheric technicians to consider making it for additional funds.

## Technical details
Modified one line per gas to update the value, and added the edit comment to them.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="553" height="244" alt="image" src="https://github.com/user-attachments/assets/d6d0750d-e6d2-4d2a-8e77-e98f87d45dd0" />
<img width="553" height="244" alt="image" src="https://github.com/user-attachments/assets/d3169fb1-2c22-4be2-93e2-5391c7eb1d60" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: N2O is 10 times more valuable now, and frezon is 4 times more valuable as well
