### PR TITLE
Replace job board with salv shuttle console + salv shuttle console fixes

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -85,6 +85,7 @@
     AmePartFlatpackStealObjective: 1
     ExpeditionsCircuitboardStealObjective: 1            #sup
     CargoShuttleCircuitboardStealObjective: 1
+    SalvageShuttleCircuitboardStealObjective: 1 # Carpmosia-edit - Job board to shuttle console + fixes
     ClothingEyesHudBeerStealObjective: 0.5              #srv, beer goggles less common cause its so easy
     BibleStealObjective: 1
     ClothingNeckGoldmedalStealObjective: 1              #other

--- a/Resources/Prototypes/_Carpmosia/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -4,6 +4,8 @@
   name: salvage shuttle console board
   description: A computer printed circuit board for a salvage shuttle console.
   components:
+    - type: Sprite
+      state: cpu_supply
     - type: ComputerBoard
       prototype: ComputerShuttleSalvage
     - type: StealTarget

--- a/Resources/_Carpmosia/migration.yml
+++ b/Resources/_Carpmosia/migration.yml
@@ -7,6 +7,6 @@
 #OldPrototypeReplaced: ReplacementPrototype
 #OldPrototypeDeleted: null
 
-# 2025-10-28 - Job board to shuttle console
+# 2025-10-28 - Job board to shuttle console + fixes
 ComputerSalvageJobBoard: ComputerShuttleSalvage
 SalvageJobBoardComputerCircuitboard: SalvageShuttleConsoleCircuitboard

--- a/Resources/_Carpmosia/migration.yml
+++ b/Resources/_Carpmosia/migration.yml
@@ -6,3 +6,7 @@
 ## YYYY-MM-DD - (PR name)
 #OldPrototypeReplaced: ReplacementPrototype
 #OldPrototypeDeleted: null
+
+# 2025-10-28 - Job board to shuttle console
+ComputerSalvageJobBoard: ComputerShuttleSalvage
+SalvageJobBoardComputerCircuitboard: SalvageShuttleConsoleCircuitboard

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -415,11 +415,11 @@ ClothingBeltSuspenders: ClothingBeltSuspendersRed
 ClothingNeckShockCollar: ClothingBackpackElectropack
 
 # 2024-08-22
-# Carpmosia-start - Job board to shuttle console
+# Carpmosia-start - Job board to shuttle console + fixes
 #ComputerShuttleSalvage: null
 #SalvageShuttleConsoleCircuitboard: null
 #SalvageShuttleCircuitboardStealObjective: null
-# Carpmosia-end - Job board to shuttle console
+# Carpmosia-end - Job board to shuttle console + fixes
 
 # 2024-08-28
 ClothingBackpackDuffelSyndicateCostumeCentcom: null

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -415,9 +415,11 @@ ClothingBeltSuspenders: ClothingBeltSuspendersRed
 ClothingNeckShockCollar: ClothingBackpackElectropack
 
 # 2024-08-22
-ComputerShuttleSalvage: null
-SalvageShuttleConsoleCircuitboard: null
-SalvageShuttleCircuitboardStealObjective: null
+# Carpmosia-start - Job board to shuttle console
+#ComputerShuttleSalvage: null
+#SalvageShuttleConsoleCircuitboard: null
+#SalvageShuttleCircuitboardStealObjective: null
+# Carpmosia-end - Job board to shuttle console
 
 # 2024-08-28
 ClothingBackpackDuffelSyndicateCostumeCentcom: null


### PR DESCRIPTION
## About the PR
Allows the salvage shuttle console to be mapped, replaces the job board with it, should allow it's steal objective to appear, and makes the console sprite fit with the rest of the cargo sprites. If the migration of the job board into the shuttle console is not desired, it can be removed.

## Why / Balance
I HATE THAT FUCKING BOARD!! With the reintroduction of the salvage shuttle it's console should be mappable and the sprite should match the sprites of other cargo specific boards. The job board has not been removed from the tote, as further salvage tweaks to loot tables are still needed.

## Technical details
Commented out old migration, added migration of job board into salv shuttle console in Carpmosia specific migration.
Added state: cpu_supply to the console board.
Added SalvageShuttleCircuitboardStealObjective to ThiefObjectiveGroupItem at weight 1.

## Media
<img width="610" height="142" alt="Screenshot 2025-10-28 080359" src="https://github.com/user-attachments/assets/7c492f5b-1877-48bb-b905-de9c6b90479e" />
<img width="403" height="133" alt="Screenshot 2025-10-28 080408" src="https://github.com/user-attachments/assets/16b30b36-dca9-471f-92cf-7515d8463078" />
<img width="695" height="387" alt="Screenshot 2025-10-28 080514" src="https://github.com/user-attachments/assets/7ffa321f-cc7c-44d5-83b2-1cc45129a6bb" />
<img width="366" height="73" alt="Screenshot 2025-10-28 082629" src="https://github.com/user-attachments/assets/aaca13b3-c7a8-4ce3-ae75-a9d054f10764" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Salvage shuttle consoles will now appear on most stations.
- remove: All mapped salvage job boards have been replaced, though it is still in the quartermaster's tote.
- fix: The salvage shuttle console board now uses the correct sprite.
- fix: The salvage shuttle console board steal objective now properly appears.
