### PR TITLE
Remove wizard as a midround antag

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -45,7 +45,7 @@
     - id: SleeperAgents
     - id: ZombieOutbreak
     - id: LoneOpsSpawn
-    - id: WizardSpawn
+      #    - id: WizardSpawn # Carpmosia-edit - Bulldoze midround wizard
     - !type:NestedSelector
       tableId: DerelictBorgEventTable
 


### PR DESCRIPTION
## About the PR
The WizardSpawn gamerule is removed from the pool of midround antags.

## Why / Balance
Insert 300 pages of malding about the state of the wizard both upstream and down here.

## Technical details
Comments out one line in ModerateAntagEventsTable.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Wizards no longer spawn during the round.