### PR TITLE
Better tourniquets

### DIFF
--- a/Resources/Locale/en-US/_Carpmosia/stack/stacks.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/stack/stacks.ftl
@@ -1,0 +1,1 @@
+stack-tourniquet = tourniquet

--- a/Resources/Locale/en-US/stack/stacks.ftl
+++ b/Resources/Locale/en-US/stack/stacks.ftl
@@ -121,8 +121,6 @@ stack-inflatable-door = inflatable door
 stack-ointment = ointment
 stack-aloe-cream = aloe cream
 stack-gauze = gauze
-# Carpmosia-edit - Better tourniquets
-stack-tourniquet = tourniquet
 stack-brutepack = brutepack
 stack-bloodpack = bloodpack
 stack-medicated-suture = medicated-suture

--- a/Resources/Locale/en-US/stack/stacks.ftl
+++ b/Resources/Locale/en-US/stack/stacks.ftl
@@ -121,6 +121,8 @@ stack-inflatable-door = inflatable door
 stack-ointment = ointment
 stack-aloe-cream = aloe cream
 stack-gauze = gauze
+# Carpmosia-edit - Better tourniquets
+stack-tourniquet = tourniquet
 stack-brutepack = brutepack
 stack-bloodpack = bloodpack
 stack-medicated-suture = medicated-suture

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -250,6 +250,7 @@
 - type: entity
   parent: BaseHealingItem
   id: Tourniquet
+  suffix: Full # Carpmosia-edit - Better tourniquets
   name: tourniquet
   description: Stops bleeding! Hopefully.
   components:
@@ -263,13 +264,15 @@
     - type: Healing
       damageContainers:
         - Biological
+      # Carpmosia-start - Better tourniquets
       damage:
-        groups:
-          Brute: 5 # Tourniquets HURT!
         types:
-          Asphyxiation: 5 # Essentially Stopping all blood reaching a part of your body
-      bloodlossModifier: -10 # Tourniquets stop bleeding
-      delay: 0.5
+         Piercing: -2
+         Slash: -2
+      bloodlossModifier: -5 # Tourniquets stop bleeding
+      delay: 2
+      selfHealPenaltyMultiplier: 2
+      # Carpmosia-end - Better tourniquets
       healingBeginSound:
         path: "/Audio/Items/Medical/brutepack_begin.ogg"
         params:
@@ -280,6 +283,19 @@
         params:
           volume: 1.0
           variation: 0.125
+# Carpmosia-start - Better tourniquets
+    - type: Stack
+      stackType: Tourniquet
+      count: 5
+
+- type: entity
+  id: Tourniquet1
+  parent: Tourniquet
+  suffix: Single
+  components:
+  - type: Stack
+    count: 1
+# Carpmosia-end - Better tourniquets
 
 - type: entity
   name: roll of gauze

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -9,6 +9,7 @@
   - TargetClown
   - TargetHuman
   - TargetSyndicate
+  - Tourniquet # Carpmosia-edit - Better tourniquets
   - Zipties
 
 # Practice ammo/mags and practice weapons

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -170,6 +170,17 @@
     Plastic: 200
     Steel: 100
 
+# Carpmosia-start - Better tourniquets
+- type: latheRecipe
+  parent: BaseToolRecipe
+  id: Tourniquet
+  result: Tourniquet1
+  completetime: 1.5
+  materials:
+    Plastic: 25
+    Steel: 10
+# Carpmosia-end - Better tourniquets
+
 ## Weapons
 
 # Melee

--- a/Resources/Prototypes/Stacks/Specific/medical.yml
+++ b/Resources/Prototypes/Stacks/Specific/medical.yml
@@ -21,6 +21,15 @@
   icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: gauze }
   spawn: Gauze
 
+# Carpmosia-start - Better tourniquets
+- type: stack
+  parent: BaseVerySmallStack
+  id: Tourniquet
+  name: stack-tourniquet
+  icon: { sprite: "/Textures/Objects/Specific/Medical/medical.rsi", state: gauze }
+  spawn: Tourniquet
+# Carpmosia-end - Better tourniquets
+
 - type: stack
   parent: BaseSmallStack
   id: Brutepack


### PR DESCRIPTION
## About the PR
Ports [Ronstation/#266](https://github.com/RonRonstation/ronstation/pull/266).

## Why / Balance
See original, and maintainers expressed desire for this to be ported.

## Technical details
Made original prototype into full stack, made it slightly heal instead of dealing damage, made it apply slower but have a lowered selfHealPenaltyMultiplier.
Added stack prototype, single prototype, and lathe recipe to security techfab.

## Media
<img width="324" height="153" alt="Screenshot 2025-11-01 105710" src="https://github.com/user-attachments/assets/bcaaa9be-34ba-4e65-9b2a-b14b15311be4" />
<img width="371" height="490" alt="Screenshot 2025-11-01 105734" src="https://github.com/user-attachments/assets/a8845ba8-5d8e-4f49-841d-52412bea0b39" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: A tourniquet recipe has been added to the security techfab.
- tweak: Tourniquets are now stackable and have had their effects tweaked to better fit their purpose.
