### PR TITLE
Implement antag playtime tracking

### DIFF
--- a/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
@@ -235,6 +235,7 @@ public sealed class JobRequirementsManager : ISharedPlaytimeManager
     public IEnumerable<KeyValuePair<string, TimeSpan>> FetchPlaytimeByRoles()
     {
         var jobsToMap = _prototypes.EnumeratePrototypes<JobPrototype>();
+        var antagsToMap = _prototypes.EnumeratePrototypes<AntagPrototype>(); // Carpmosia-edit - Antag playtimes
 
         foreach (var job in jobsToMap)
         {
@@ -243,6 +244,15 @@ public sealed class JobRequirementsManager : ISharedPlaytimeManager
                 yield return new KeyValuePair<string, TimeSpan>(job.Name, locJobName);
             }
         }
+        // Carpmosia-start - Antag playtimes
+        foreach (var antag in antagsToMap)
+        {
+            if (_roles.TryGetValue(antag.PlayTimeTracker, out var locAntagName))
+            {
+                yield return new KeyValuePair<string, TimeSpan>(antag.Name, locAntagName);
+            }
+        }
+        // Carpmosia-end - Antag playtimes
     }
 
     public IReadOnlyDictionary<string, TimeSpan> GetPlayTimes(ICommonSession session)

--- a/Content.Shared/Roles/AntagPrototype.cs
+++ b/Content.Shared/Roles/AntagPrototype.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Guidebook;
+using Content.Shared.Players.PlayTimeTracking; // Carpmosia-edit - Antag playtimes
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype; // Carpmosia-edit - Antag playtimes
 
 namespace Content.Shared.Roles;
 
@@ -19,6 +20,17 @@ public sealed partial class AntagPrototype : IPrototype
     [ViewVariables]
     [IdDataField]
     public string ID { get; private set; } = default!;
+
+    // Carpmosia-start - Antag playtimes
+    [DataField("playTimeTracker", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<PlayTimeTrackerPrototype>))]
+    public string PlayTimeTracker { get; private set; } = string.Empty;
+
+    [DataField("color")]
+    public Color Color { get; private set; } = Color.Yellow;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public string LocalizedName => Loc.GetString(Name);
+    // Carpmosia-end - Antag playtimes
 
     /// <summary>
     ///     The name of this antag as displayed to players.

--- a/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/RoleTimeRequirement.cs
@@ -48,8 +48,23 @@ public sealed partial class RoleTimeRequirement : JobRequirement
         if (jobSystem.TryGetDepartment(jobProto, out var departmentProto))
             departmentColor = departmentProto.Color;
 
-        if (!protoManager.TryIndex<JobPrototype>(jobProto, out var indexedJob))
+        // Carpmosia-start - Antag playtimes
+        var localizedName = "";
+
+        if (protoManager.TryIndex<JobPrototype>(jobProto, out var indexedJob))
+        {
+            localizedName = indexedJob.LocalizedName;
+        }
+        else if(protoManager.TryIndex<AntagPrototype>(jobProto, out var indexedAntag))
+        {
+            localizedName = indexedAntag.LocalizedName;
+            departmentColor = indexedAntag.Color;
+        }
+        else
+        {
             return false;
+        }
+        // Carpmosia-end - Antag playtimes
 
         if (!Inverted)
         {
@@ -59,7 +74,7 @@ public sealed partial class RoleTimeRequirement : JobRequirement
             reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
                 "role-timer-role-insufficient",
                 ("time", formattedRoleDiff),
-                ("job", indexedJob.LocalizedName),
+                ("job", localizedName), // Carpmosia-edit - Antag playtimes
                 ("departmentColor", departmentColor.ToHex())));
             return false;
         }
@@ -69,7 +84,7 @@ public sealed partial class RoleTimeRequirement : JobRequirement
             reason = FormattedMessage.FromMarkupPermissive(Loc.GetString(
                 "role-timer-role-too-high",
                 ("time", formattedRoleDiff),
-                ("job", indexedJob.LocalizedName),
+                ("job", localizedName), // Carpmosia-edit - Antag playtimes
                 ("departmentColor", departmentColor.ToHex())));
             return false;
         }

--- a/Content.Shared/Roles/Jobs/SharedJobSystem.cs
+++ b/Content.Shared/Roles/Jobs/SharedJobSystem.cs
@@ -29,7 +29,7 @@ public abstract class SharedJobSystem : EntitySystem
 
     private void OnProtoReload(PrototypesReloadedEventArgs obj)
     {
-        if (obj.WasModified<JobPrototype>())
+        if (obj.WasModified<JobPrototype>() || obj.WasModified<AntagPrototype>()) // Carpmosia-edit - Antag playtimes
             SetupTrackerLookup();
     }
 
@@ -42,6 +42,12 @@ public abstract class SharedJobSystem : EntitySystem
         {
             _inverseTrackerLookup.Add(job.PlayTimeTracker, job.ID);
         }
+        // Carpmosia-start - Antag playtimes
+        foreach (var antag in _prototypes.EnumeratePrototypes<AntagPrototype>())
+        {
+            _inverseTrackerLookup.Add(antag.PlayTimeTracker, antag.ID);
+        }
+        // Carpmosia-end - Antag playtimes
     }
 
     /// <summary>

--- a/Content.Shared/Roles/SharedRoleSystem.cs
+++ b/Content.Shared/Roles/SharedRoleSystem.cs
@@ -586,6 +586,7 @@ public abstract class SharedRoleSystem : EntitySystem
                 prototype = comp.AntagPrototype;
                 if (_prototypes.TryIndex(comp.AntagPrototype, out var antag))
                 {
+                    playTimeTracker = antag.PlayTimeTracker; // Carpmosia-edit - Antag playtimes
                     name = antag.Name;
                     valid = true;
                 }

--- a/Resources/Locale/en-US/_Carpmosia/job/job-names.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/job/job-names.ftl
@@ -1,0 +1,23 @@
+# Role timers - Make these alphabetical
+AntagChangeling = Changeling
+AntagDragon = Space Dragon
+AntagGenericAntagonist = Antagonist
+AntagGenericFreeAgent = Free Agent
+AntagGenericSiliconAntagonist = Silicon Antagonist
+AntagGenericTeamAntagonist = Team Antagonist
+AntagHeadRev = Head Revolutionary
+AntagInitialInfected = Initial Infected
+AntagNukeops = Nuclear Operative
+AntagNukeopsCommander = Nuclear Operative Commander
+AntagNukeopsMedic = Nuclear Operative Medic
+AntagParadoxClone = Paradox Clone
+AntagRev = Revolutionary
+AntagSpaceNinja = Space Ninja
+AntagSubvertedSilicon = Subverted Silicon
+AntagSurvivor = Survivor
+AntagThief = Thief
+AntagTraitor = Syndicate Agent
+AntagTraitorSleeper = Syndicate Sleeper Agent
+AntagVampire = Vampire
+AntagWizard = Wizard
+AntagZombie = Zombie

--- a/Resources/Prototypes/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/Roles/Antags/changeling.yml
@@ -1,6 +1,10 @@
 ﻿- type: antag
   id: Changeling
   name: roles-antag-changeling-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagChangeling
+  color: '#FA2A55'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   setPreference: false # TODO: set this to true once Changeling exits WIP status
   objective: roles-antag-changeling-objective

--- a/Resources/Prototypes/Roles/Antags/dragon.yml
+++ b/Resources/Prototypes/Roles/Antags/dragon.yml
@@ -1,5 +1,9 @@
 - type: antag
   id: Dragon
   name: roles-antag-dragon-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagDragon
+  color: '#D82000'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   objective: roles-antag-dragon-objective

--- a/Resources/Prototypes/Roles/Antags/generic.yml
+++ b/Resources/Prototypes/Roles/Antags/generic.yml
@@ -1,23 +1,27 @@
 - type: antag
   id: GenericAntagonist
   name: roles-antag-generic-solo-antagonist-name
+  playTimeTracker: AntagGenericAntagonist # Carpmosia-edit - Antag playtimes
   antagonist: true
   objective: never-shown
 
 - type: antag
   id: GenericTeamAntagonist
   name: roles-antag-generic-team-antagonist-name
+  playTimeTracker: AntagGenericTeamAntagonist # Carpmosia-edit - Antag playtimes
   antagonist: true
   objective: never-shown
 
 - type: antag
   id: GenericFreeAgent
   name: roles-antag-generic-free-agent-name
+  playTimeTracker: AntagGenericFreeAgent # Carpmosia-edit - Antag playtimes
   antagonist: true
   objective: never-shown
 
 - type: antag
   id: GenericSiliconAntagonist
   name: roles-antag-generic-silicon-antagonist-name
+  playTimeTracker: AntagGenericSiliconAntagonist # Carpmosia-edit - Antag playtimes
   antagonist: true
   objective: never-shown

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -1,6 +1,10 @@
 - type: antag
   id: SpaceNinja
   name: roles-antag-space-ninja-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagSpaceNinja
+  color: '#33CC00'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   setPreference: false
   objective: roles-antag-space-ninja-objective

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -1,6 +1,10 @@
 - type: antag
   id: Nukeops
   name: roles-antag-nuclear-operative-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagNukeops
+  color: '#8B0000'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   setPreference: true
   objective: roles-antag-nuclear-operative-objective
@@ -12,6 +16,10 @@
 - type: antag
   id: NukeopsMedic
   name: roles-antag-nuclear-operative-agent-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagNukeopsMedic
+  color: '#8B0000'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   setPreference: true
   objective: roles-antag-nuclear-operative-agent-objective
@@ -26,16 +34,21 @@
 - type: antag
   id: NukeopsCommander
   name: roles-antag-nuclear-operative-commander-name
+  # Carpmosia-start - Antag playtimesS
+  playTimeTracker: AntagNukeopsCommander
+  color: '#8B0000'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   setPreference: true
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 5h
-  - !type:DepartmentTimeRequirement
-    department: Security
+  # Carpmosia-start - Antag playtimes
+  - !type:RoleTimeRequirement
+    role: AntagNukeops
     time: 5h
-  # should be changed to nukie playtime when thats tracked (wyci)
+  # Carpmosia-end - Antag playtimes
   guides: [ NuclearOperatives ]
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/paradoxClone.yml
+++ b/Resources/Prototypes/Roles/Antags/paradoxClone.yml
@@ -1,6 +1,10 @@
 - type: antag
   id: ParadoxClone
   name: roles-antag-paradox-clone-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagParadoxClone
+  color: '#D82000'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   objective: roles-antag-paradox-clone-objective
   setPreference: false

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -1,6 +1,10 @@
 - type: antag
   id: HeadRev
   name: roles-antag-rev-head-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagHeadRev
+  color: '#5E9CFF'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   setPreference: true
   objective: roles-antag-rev-head-objective
@@ -12,6 +16,10 @@
 - type: antag
   id: Rev
   name: roles-antag-rev-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagRev
+  color: '#5E9CFF'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   setPreference: false
   objective: roles-antag-rev-objective

--- a/Resources/Prototypes/Roles/Antags/silicon.yml
+++ b/Resources/Prototypes/Roles/Antags/silicon.yml
@@ -1,6 +1,10 @@
 - type: antag
   id: SubvertedSilicon
   name: roles-antag-subverted-silicon-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagSubvertedSilicon
+  color: '#c832e6'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   setPreference: false
   objective: roles-antag-subverted-silicon-objective

--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -1,6 +1,10 @@
 - type: antag
   id: Thief
   name: roles-antag-thief-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagThief
+  color: '#D82000'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   setPreference: true
   objective: roles-antag-thief-objective

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -1,6 +1,10 @@
 - type: antag
   id: Traitor
   name: roles-antag-syndicate-agent-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagTraitor
+  color: '#D82000'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   setPreference: true
   objective: roles-antag-syndicate-agent-objective
@@ -12,6 +16,10 @@
 - type: antag
   id: TraitorSleeper
   name: roles-antag-syndicate-agent-sleeper-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagTraitorSleeper
+  color: '#D82000'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   setPreference: true
   objective: roles-antag-syndicate-agent-sleeper-objective

--- a/Resources/Prototypes/Roles/Antags/wizard.yml
+++ b/Resources/Prototypes/Roles/Antags/wizard.yml
@@ -1,6 +1,10 @@
 - type: antag
   id: Survivor
   name: roles-antag-survivor-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagSurvivor
+  color: '#ffff00'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   objective: roles-antag-survivor-objective
   # guides: [  ]
@@ -8,6 +12,10 @@
 - type: antag
   id: Wizard
   name: roles-antag-wizard-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagWizard
+  color: '#40E0D0'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   # setPreference: true # Disabled as roundstart gamemode until reworked
   objective: roles-antag-wizard-objective # TODO: maybe give random objs and stationary ones from AntagObjectives and AntagRandomObjectives

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -1,6 +1,10 @@
 - type: antag
   id: InitialInfected
   name: roles-antag-initial-infected-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagInitialInfected
+  color: '#DDA0DD'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   setPreference: true
   objective: roles-antag-initial-infected-objective
@@ -12,6 +16,10 @@
 - type: antag
   id: Zombie
   name: roles-antag-zombie-name
+  # Carpmosia-start - Antag playtimes
+  playTimeTracker: AntagZombie
+  color: '#DDA0DD'
+  # Carpmosia-end - Antag playtimes
   antagonist: true
   setPreference: false
   objective: roles-antag-zombie-objective

--- a/Resources/Prototypes/_Carpmosia/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/_Carpmosia/Roles/play_time_trackers.yml
@@ -1,0 +1,66 @@
+# Antags
+- type: playTimeTracker
+  id: AntagChangeling
+
+- type: playTimeTracker
+  id: AntagDragon
+
+- type: playTimeTracker
+  id: AntagGenericAntagonist
+
+- type: playTimeTracker
+  id: AntagGenericFreeAgent
+
+- type: playTimeTracker
+  id: AntagGenericSiliconAntagonist
+
+- type: playTimeTracker
+  id: AntagGenericTeamAntagonist
+
+- type: playTimeTracker
+  id: AntagHeadRev
+
+- type: playTimeTracker
+  id: AntagInitialInfected
+
+- type: playTimeTracker
+  id: AntagNukeops
+
+- type: playTimeTracker
+  id: AntagNukeopsCommander
+
+- type: playTimeTracker
+  id: AntagNukeopsMedic
+
+- type: playTimeTracker
+  id: AntagParadoxClone
+
+- type: playTimeTracker
+  id: AntagRev
+
+- type: playTimeTracker
+  id: AntagSpaceNinja
+
+- type: playTimeTracker
+  id: AntagSubvertedSilicon
+
+- type: playTimeTracker
+  id: AntagSurvivor
+
+- type: playTimeTracker
+  id: AntagThief
+
+- type: playTimeTracker
+  id: AntagTraitor
+
+- type: playTimeTracker
+  id: AntagTraitorSleeper
+
+- type: playTimeTracker
+  id: AntagVampire
+
+- type: playTimeTracker
+  id: AntagWizard
+
+- type: playTimeTracker
+  id: AntagZombie


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

Ported my PR from RonRonstation/ronstation#364

## About the PR
<!-- What did you change? -->
- [x] Added playtime tracking to all antag roles
- [x] Implemented coloring for antag time requirements
- [x] Rplaced Nukeops Commander playtime requirement from Security to Nukeops

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Needed

## Technical details
<!-- Summary of code changes for easier review. -->
Added PlayTimeTracker field to AntagPrototype, made SharedJobSystem tracker update time tracker from it too, utilized it in the SharedRoleSystem, and made JobRequirementsManager fetch antag playtime too
Also added trackers for each antag and added them too the antags

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="358" height="164" alt="image" src="https://github.com/user-attachments/assets/32aa506f-fa23-4c0f-8700-f6aae7d2558d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Atakku
- add: Implemented antag time tracking
- tweak: Replaced Nukeops Commander's playtime requirement from Security to Nukeops
