### PR TITLE
Set the maxplayer limit of saltern-II to be somewhat similar to packed.

### DIFF
--- a/Resources/Prototypes/_Carpmosia/Maps/saltern-2.yml
+++ b/Resources/Prototypes/_Carpmosia/Maps/saltern-2.yml
@@ -3,7 +3,7 @@
   mapName: 'Saltern-II'
   mapPath: /Maps/_Carpmosia/saltern-2.yml
   minPlayers: 0
-  maxPlayers: 20
+  maxPlayers: 30
   fallback: true
   stations:
     Saltern:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Set the max player limit for saltern-II to 30, instead of 20 (which was a change I should have immediately rejected).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We're rarely below 20 players, meaning this map would rarely show up. This was meant to create more options until we hit the minimum limit for mid-pop maps. Instead, right now there's a pretty sizable window where the only map selections are amber, packed and elkridge, the exact thing I was trying to solve by adding in saltern.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:

- fix: Revert the requested change to Saltern-II's max player limit, as it is too low to bridge the gap to mid-pop maps.
