### PR TITLE
Add maid dresses to loadouts of Bartenders, Chefs and Service Workers

### DIFF
--- a/Resources/Prototypes/_Carpmosia/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -1,0 +1,10 @@
+- type: entity
+  parent: ClothingUniformSkirtBase
+  id: ClothingUniformJumpskirtServicemaid
+  name: service maid uniform
+  description: For professionals, not the posers.\nHold on, isn't this just the janitorial maid dress?
+  components:
+  - type: Sprite
+    sprite: Clothing/Uniforms/Jumpskirt/janimaid.rsi
+  - type: Clothing
+    sprite: Clothing/Uniforms/Jumpskirt/janimaid.rsi

--- a/Resources/Prototypes/_Carpmosia/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -2,7 +2,7 @@
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtServicemaid
   name: service maid uniform
-  description: For professionals, not the posers.\nHold on, isn't this just the janitorial maid dress?
+  description: For professionals, not the posers. Hold on, isn't this just the janitorial maid dress?
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpskirt/janimaid.rsi

--- a/Resources/Prototypes/_Carpmosia/Loadouts/Groups/Civilian/bartender.yml
+++ b/Resources/Prototypes/_Carpmosia/Loadouts/Groups/Civilian/bartender.yml
@@ -28,6 +28,7 @@
   - BartenderJumpsuit
   - BartenderJumpskirt
   - BartenderJumpsuitPurple
+  - ServiceMaidskirt
 
 - type: loadoutGroup
   parent: [ CivilianBackpack, CommonBackpack ]

--- a/Resources/Prototypes/_Carpmosia/Loadouts/Groups/Civilian/chef.yml
+++ b/Resources/Prototypes/_Carpmosia/Loadouts/Groups/Civilian/chef.yml
@@ -28,6 +28,7 @@
   loadouts:
   - ChefJumpsuit
   - ChefJumpskirt
+  - ServiceMaidskirt
 
 - type: loadoutGroup
   parent: [ CivilianBackpack, CommonBackpack ]

--- a/Resources/Prototypes/_Carpmosia/Loadouts/Groups/Civilian/service_worker.yml
+++ b/Resources/Prototypes/_Carpmosia/Loadouts/Groups/Civilian/service_worker.yml
@@ -25,6 +25,7 @@
   - BartenderJumpsuit
   - BartenderJumpskirt
   - BartenderJumpsuitPurple
+  - ServiceMaidskirt
 
 - type: loadoutGroup
   parent: [ CivilianBackpack, CommonBackpack ]

--- a/Resources/Prototypes/_Carpmosia/Loadouts/Jobs/Civilian/service.yml
+++ b/Resources/Prototypes/_Carpmosia/Loadouts/Jobs/Civilian/service.yml
@@ -1,0 +1,17 @@
+- type: loadoutEffectGroup
+  id: CompetentService
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Civilian
+      time: 20h
+
+# Jumpsuit
+- type: loadout
+  id: ServiceMaidskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: CompetentService
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtServicemaid


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the brand new* Service Maid dress to roundstart loadouts of Bartenders, Chefs and Service Workers, with a 20h Civilian department timelock


<sub> *may actually just be the janitor maidskirt </sub>
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<img width="742" height="411" alt="obraz" src="https://github.com/user-attachments/assets/1aa8e6cc-ccf8-4631-86e4-1be71d3fcee8" />

:godo:

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new prototype for a maid dress with a changed name and description, added it to all the aforementioned loadouts  locked behind a 20h civilian department timelock

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: korczoczek

- tweak: Bartenders, Chefs and Service Workers can now choose the service maid dress as a roundstart jumpskirt, locked behind a 20h civilian department timelock


