### PR TITLE
Insert storage contents into biogenerator

### DIFF
--- a/Content.Server/Materials/ProduceMaterialExtractorSystem.cs
+++ b/Content.Server/Materials/ProduceMaterialExtractorSystem.cs
@@ -26,7 +26,7 @@ public sealed class ProduceMaterialExtractorSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<ProduceMaterialExtractorComponent, AfterInteractUsingEvent>(OnInteractUsing);
-        SubscribeLocalEvent<ProduceMaterialExtractorComponent, ContainerDoAfterEvent>(OnContainerDoAfter); // Carpmosia-edit - Insert storage contents into biogenerator
+        SubscribeLocalEvent<ProduceMaterialExtractorComponent, BiogenDoAfterEvent>(OnBiogenDoAfter); // Carpmosia-edit - Insert storage contents into biogenerator
     }
 
     private void OnInteractUsing(Entity<ProduceMaterialExtractorComponent> ent, ref AfterInteractUsingEvent args)
@@ -40,7 +40,7 @@ public sealed class ProduceMaterialExtractorSystem : EntitySystem
         // Carpmosia-start - Insert storage contents into biogenerator
         if (HasComp<StorageComponent>(args.Used))
         {
-            var doAfter = new DoAfterArgs(EntityManager, args.User, 0.5f, new ContainerDoAfterEvent(), ent, ent, used: args.Used)
+            var doAfter = new DoAfterArgs(EntityManager, args.User, 0.5f, new BiogenDoAfterEvent(), ent, ent, used: args.Used)
             {
                 BreakOnDamage = true,
                 NeedHand = true,
@@ -88,32 +88,36 @@ public sealed class ProduceMaterialExtractorSystem : EntitySystem
     /// <param name="uid">The biogen uid</param>
     /// <param name="comp">The material extractor component</param>
     /// <param name="args">DoAfter args</param>
-    private void OnContainerDoAfter(EntityUid uid, ProduceMaterialExtractorComponent comp, ContainerDoAfterEvent args)
+    private void OnBiogenDoAfter(EntityUid uid, ProduceMaterialExtractorComponent comp, BiogenDoAfterEvent args)
     {
+        if (args.Cancelled || args.Handled || args.Target == null)
+            return;
+
         // If there's no storage component, we leave
         if (!TryComp<StorageComponent>(args.Used, out var storage))
             return;
+
         // If the storage is empty, we leave
         if (storage.StoredItems.Count == 0)
             return;
+
         // Find every valid item and convert it to biomass
         foreach (var (item, _location) in storage.StoredItems)
         {
             if (!TryComp<ProduceComponent>(item, out var produce))
                 continue;
 
-            if (_solutionContainer.TryGetSolution(item, produce.SolutionName, out var solution))
-            {
-                var matAmount = solution.Value.Comp.Solution.Contents
+            if (!_solutionContainer.TryGetSolution(item, produce.SolutionName, out var solution))
+                continue;
+
+            var matAmount = solution.Value.Comp.Solution.Contents
                 .Where(r => comp.ExtractionReagents.Contains(r.Reagent.Prototype))
                 .Sum(r => r.Quantity.Float());
 
-                var changed = (int)matAmount;
+            var changed = (int)matAmount;
 
-                _materialStorage.TryChangeMaterialAmount(comp.Owner, comp.ExtractedMaterial, changed);
-                QueueDel(item);
-            }
-
+            _materialStorage.TryChangeMaterialAmount(comp.Owner, comp.ExtractedMaterial, changed);
+            QueueDel(item);
         }
 
         _audio.PlayPvs(comp.ExtractSound, comp.Owner);

--- a/Content.Server/Materials/ProduceMaterialExtractorSystem.cs
+++ b/Content.Server/Materials/ProduceMaterialExtractorSystem.cs
@@ -3,9 +3,13 @@ using Content.Server.Botany.Components;
 using Content.Server.Materials.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.DoAfter; // Carpmosia-edit - Insert storage contents into biogenerator
 using Content.Shared.Interaction;
+using Content.Shared.Materials; // Carpmosia-edit - Insert storage contents into biogenerator
 using Content.Shared.Popups;
+using Content.Shared.Storage; // Carpmosia-edit - Insert storage contents into biogenerator
 using Robust.Server.Audio;
+using Robust.Shared.Containers; // Carpmosia-edit - Insert storage contents into biogenerator
 
 namespace Content.Server.Materials;
 
@@ -13,13 +17,16 @@ public sealed class ProduceMaterialExtractorSystem : EntitySystem
 {
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly MaterialStorageSystem _materialStorage = default!;
+    [Dependency] private readonly SharedContainerSystem _containerSystem = default!; // Carpmosia-edit - Insert storage contents into biogenerator
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!; // Carpmosia-edit - Insert storage contents into biogenerator
 
     /// <inheritdoc/>
     public override void Initialize()
     {
         SubscribeLocalEvent<ProduceMaterialExtractorComponent, AfterInteractUsingEvent>(OnInteractUsing);
+        SubscribeLocalEvent<ProduceMaterialExtractorComponent, ContainerDoAfterEvent>(OnContainerDoAfter); // Carpmosia-edit - Insert storage contents into biogenerator
     }
 
     private void OnInteractUsing(Entity<ProduceMaterialExtractorComponent> ent, ref AfterInteractUsingEvent args)
@@ -30,30 +37,87 @@ public sealed class ProduceMaterialExtractorSystem : EntitySystem
         if (!this.IsPowered(ent, EntityManager))
             return;
 
-        if (!TryComp<ProduceComponent>(args.Used, out var produce))
-            return;
-
-        if (!_solutionContainer.TryGetSolution(args.Used, produce.SolutionName, out var solution))
-            return;
-
-        // Can produce even have fractional amounts? Does it matter if they do?
-        // Questions man was never meant to answer.
-        var matAmount = solution.Value.Comp.Solution.Contents
-            .Where(r => ent.Comp.ExtractionReagents.Contains(r.Reagent.Prototype))
-            .Sum(r => r.Quantity.Float());
-
-        var changed = (int)matAmount;
-
-        if (changed == 0)
+        // Carpmosia-start - Insert storage contents into biogenerator
+        if (HasComp<StorageComponent>(args.Used))
         {
-            _popup.PopupEntity(Loc.GetString("material-extractor-comp-wrongreagent", ("used", args.Used)), args.User, args.User);
+            var doAfter = new DoAfterArgs(EntityManager, args.User, 0.5f, new ContainerDoAfterEvent(), ent, ent, used: args.Used)
+            {
+                BreakOnDamage = true,
+                NeedHand = true,
+                BreakOnMove = true,
+                BreakOnWeightlessMove = true,
+            };
+            _doAfterSystem.TryStartDoAfter(doAfter);
+        }
+        else
+        {
+            if (!TryComp<ProduceComponent>(args.Used, out var produce))
+                return;
+
+            if (!_solutionContainer.TryGetSolution(args.Used, produce.SolutionName, out var solution))
+                return;
+
+            // Can produce even have fractional amounts? Does it matter if they do?
+            // Questions man was never meant to answer.
+            var matAmount = solution.Value.Comp.Solution.Contents
+                .Where(r => ent.Comp.ExtractionReagents.Contains(r.Reagent.Prototype))
+                .Sum(r => r.Quantity.Float());
+
+            var changed = (int)matAmount;
+
+            if (changed == 0)
+            {
+                _popup.PopupEntity(Loc.GetString("material-extractor-comp-wrongreagent", ("used", args.Used)), args.User, args.User);
+                return;
+            }
+
+            _materialStorage.TryChangeMaterialAmount(ent, ent.Comp.ExtractedMaterial, changed);
+
+            _audio.PlayPvs(ent.Comp.ExtractSound, ent);
+            QueueDel(args.Used);
+            args.Handled = true;
+        }
+        // Carpmosia-end - Insert storage contents into biogenerator
+    }
+
+    // Carpmosia-start - Insert storage contents into biogenerator
+    /// <summary>
+    /// DoAfter function for interacting with the biogenerator with an item with a storage component.
+    /// Converts any valid items in the storage into biomass for the biogenerator.
+    /// </summary>
+    /// <param name="uid">The biogen uid</param>
+    /// <param name="comp">The material extractor component</param>
+    /// <param name="args">DoAfter args</param>
+    private void OnContainerDoAfter(EntityUid uid, ProduceMaterialExtractorComponent comp, ContainerDoAfterEvent args)
+    {
+        // If there's no storage component, we leave
+        if (!TryComp<StorageComponent>(args.Used, out var storage))
             return;
+        // If the storage is empty, we leave
+        if (storage.StoredItems.Count == 0)
+            return;
+        // Find every valid item and convert it to biomass
+        foreach (var (item, _location) in storage.StoredItems)
+        {
+            if (!TryComp<ProduceComponent>(item, out var produce))
+                continue;
+
+            if (_solutionContainer.TryGetSolution(item, produce.SolutionName, out var solution))
+            {
+                var matAmount = solution.Value.Comp.Solution.Contents
+                .Where(r => comp.ExtractionReagents.Contains(r.Reagent.Prototype))
+                .Sum(r => r.Quantity.Float());
+
+                var changed = (int)matAmount;
+
+                _materialStorage.TryChangeMaterialAmount(comp.Owner, comp.ExtractedMaterial, changed);
+                QueueDel(item);
+            }
+
         }
 
-        _materialStorage.TryChangeMaterialAmount(ent, ent.Comp.ExtractedMaterial, changed);
-
-        _audio.PlayPvs(ent.Comp.ExtractSound, ent);
-        QueueDel(args.Used);
+        _audio.PlayPvs(comp.ExtractSound, comp.Owner);
         args.Handled = true;
     }
+    // Carpmosia-end - Insert storage contents into biogenerator
 }

--- a/Content.Shared/_Carpmosia/Materials/Events/BiogenDoAfterEvent.cs
+++ b/Content.Shared/_Carpmosia/Materials/Events/BiogenDoAfterEvent.cs
@@ -3,4 +3,4 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Materials;
 [Serializable, NetSerializable]
-public sealed partial class ContainerDoAfterEvent : SimpleDoAfterEvent { }
+public sealed partial class BiogenDoAfterEvent : SimpleDoAfterEvent { }

--- a/Content.Shared/_Carpmosia/Materials/Events/ContainerDoAfterEvent.cs
+++ b/Content.Shared/_Carpmosia/Materials/Events/ContainerDoAfterEvent.cs
@@ -1,0 +1,6 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Materials;
+[Serializable, NetSerializable]
+public sealed partial class ContainerDoAfterEvent : SimpleDoAfterEvent { }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds an event with a do-after that allows you to transfer the valid contents of a held container into a biogenerator, converting it into biomass.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Same treatment given to reagent grinders in https://github.com/carpmosia/carpmosia/pull/9. This is a nice change for convenience in botany that will also make it easier on my old man hands.
## Technical details
<!-- Summary of code changes for easier review. -->
Pretty major rework of ProduceMaterialExtractorSystem to allow for held storage entities to work (IE bags, plant bags, what have you). 
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/85197197-1a77-436e-a29b-58970767e0a6


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Does rely on comp.Owner to access the ProduceMaterialExtractor entity, which will probably be deprecated some day.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: You may now dump held bags directly into a biogenerator. Valid produce will be converted into biomass as normal.

