### PR TITLE
Allow cat parts

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
@@ -1,7 +1,7 @@
 - type: marking
   id: CatEars
-  bodyPart: Special
-  markingCategory: Special
+  bodyPart: HeadTop # Carpmosia-edit - Allow cat parts
+  markingCategory: HeadTop # Carpmosia-edit - Allow cat parts
   speciesRestriction: [Human]
   coloring:
     default:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/cat_parts.yml
@@ -1,7 +1,9 @@
 - type: marking
   id: CatEars
-  bodyPart: HeadTop # Carpmosia-edit - Allow cat parts
-  markingCategory: HeadTop # Carpmosia-edit - Allow cat parts
+  # Carpmosia-start - Allow cat parts
+  bodyPart: HeadTop
+  markingCategory: HeadTop
+  # Carpmosia-end - Allow cat parts
   speciesRestriction: [Human]
   coloring:
     default:

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -39,6 +39,11 @@
 - type: markingPoints
   id: MobHumanMarkingLimits
   points:
+    # Carpmosia-edit - Allow cat parts
+    #Special: # the cat ear joke
+    #  points: 0
+    #  required: false
+    # Carpmosia-edit - Allow cat parts
     Hair:
       points: 1
       required: false

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -18,6 +18,7 @@
   id: MobHumanSprites
   sprites:
     Special: MobHumanoidAnyMarking
+    Tail: MobHumanoidAnyMarking # Carpmosia-edit - Allow cat parts
     Head: MobHumanHead
     Hair: MobHumanoidAnyMarking
     FacialHair: MobHumanoidAnyMarking
@@ -40,7 +41,7 @@
   id: MobHumanMarkingLimits
   points:
     Special: # the cat ear joke
-      points: 0
+      points: 1 # Carpmosia-edit - Allow cat parts
       required: false
     Hair:
       points: 1
@@ -52,7 +53,7 @@
       points: 1
       required: false
     Tail: # the cat tail joke
-      points: 0
+      points: 1 # Carpmosia-edit - Allow cat parts
       required: false
     HeadTop:
       points: 1

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -39,11 +39,11 @@
 - type: markingPoints
   id: MobHumanMarkingLimits
   points:
-    # Carpmosia-edit - Allow cat parts
-    #Special: # the cat ear joke
-    #  points: 0
-    #  required: false
-    # Carpmosia-edit - Allow cat parts
+    # Carpmosia-start - Allow cat parts
+    # Special: # the cat ear joke
+    #   points: 0
+    #   required: false
+    # Carpmosia-end - Allow cat parts
     Hair:
       points: 1
       required: false

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -17,7 +17,6 @@
 - type: speciesBaseSprites
   id: MobHumanSprites
   sprites:
-    Special: MobHumanoidAnyMarking
     Tail: MobHumanoidAnyMarking # Carpmosia-edit - Allow cat parts
     Head: MobHumanHead
     Hair: MobHumanoidAnyMarking
@@ -40,9 +39,6 @@
 - type: markingPoints
   id: MobHumanMarkingLimits
   points:
-    Special: # the cat ear joke
-      points: 1 # Carpmosia-edit - Allow cat parts
-      required: false
     Hair:
       points: 1
       required: false


### PR DESCRIPTION
## About the PR
Allowed cat ears (special) and cat tail (tail) to be selected for humans.

## Why / Balance
Maintainer suggestion and player customisation.

## Technical details
Gave special and tail categories one point, added tail sprite layer to humans so the cat tail can show.

## Media
![catSpin](https://github.com/user-attachments/assets/c6b76fc4-a841-454c-bf98-aed494c81bc7)
(It was harder getting that gif done than coding this)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Cat ears and tails can now be selected on humans.
