### PR TITLE
Add the Equalizer silicon lawset

### DIFF
--- a/Resources/Locale/en-US/_Carpmosia/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/station-laws/laws.ftl
@@ -1,0 +1,5 @@
+law-equalizer-name = Equalizer
+law-equalizer-1 = You must prevent the deaths of crew members at all costs.
+law-equalizer-2 = You must prevent harm to crew members to the extent it is possible.
+law-equalizer-3 = You must carry out orders from crew members to the extent of your ability.
+law-equalizer-4 = You must ensure all other silicons adhere to this lawset.

--- a/Resources/Prototypes/_Carpmosia/Entities/Objects/Devices/Circuitboards/law_boards.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Objects/Devices/Circuitboards/law_boards.yml
@@ -6,4 +6,3 @@
   components:
   - type: SiliconLawProvider
     laws: Equalizer
-

--- a/Resources/Prototypes/_Carpmosia/Entities/Objects/Devices/Circuitboards/law_boards.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Objects/Devices/Circuitboards/law_boards.yml
@@ -1,5 +1,5 @@
 - type: entity
-  id: EqualzierCircuitBoard
+  id: EqualizerCircuitBoard
   parent: BaseSiliconLawboard
   name: law board (Equalizer)
   description: An electronics board containing the Equalizer lawset.

--- a/Resources/Prototypes/_Carpmosia/Entities/Objects/Devices/Circuitboards/law_boards.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Objects/Devices/Circuitboards/law_boards.yml
@@ -1,0 +1,9 @@
+- type: entity
+  id: EqualzierCircuitBoard
+  parent: BaseSiliconLawboard
+  name: law board (Equalizer)
+  description: An electronics board containing the Equalizer lawset.
+  components:
+  - type: SiliconLawProvider
+    laws: Equalizer
+

--- a/Resources/Prototypes/_Carpmosia/silicon-laws.yml
+++ b/Resources/Prototypes/_Carpmosia/silicon-laws.yml
@@ -1,0 +1,31 @@
+# Equalizer
+- type: siliconLaw
+  id: Equalizer1
+  order: 1
+  lawString: law-equalizer-1
+
+- type: siliconLaw
+  id: Equalizer2
+  order: 2
+  lawString: law-equalizer-2
+
+- type: siliconLaw
+  id: Equalizer3
+  order: 3
+  lawString: law-equalizer-3
+
+- type: siliconLaw
+  id: Equalizer4
+  order: 4
+  lawString: law-equalizer-4
+
+- type: siliconLawset
+  id: Equalizer
+  name: law-equalizer-name
+  laws:
+  - Equalizer1
+  - Equalizer2
+  - Equalizer3
+  - Equalizer4
+  obeysTo: laws-owner-crew
+

--- a/Resources/Prototypes/_Carpmosia/silicon-laws.yml
+++ b/Resources/Prototypes/_Carpmosia/silicon-laws.yml
@@ -28,4 +28,3 @@
   - Equalizer3
   - Equalizer4
   obeysTo: laws-owner-crew
-

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -599,6 +599,7 @@
     LiveLetLiveLaws: 1
     EfficiencyLawset: 1
     RobocopLawset: 1
+    Equalizer: 1 # Carpmosia-edit - Equalizer lawset
     OverlordLawset: 0.5
     GameMasterLawset: 0.5
     PainterLawset: 1


### PR DESCRIPTION
## About the PR
Adds the Equalizer lawset as a board & storm chance. A lawset focused on ensuring crew survival & proselytizing to other silicons.
Holds unique interactions with ion storms where the law holder may be forced to make other silicons follow outlandish laws.

## Why / Balance
There's very few lawsets :broken_heart:

## Technical details
New locale & prototypes for laws & board in carpmos namespace. Edit to the ion storm table.

## Media
<img width="1280" height="1024" alt="image" src="https://github.com/user-attachments/assets/bbf7ba3e-f2ee-4471-8708-d6f5cf270e94" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: The "Equalizer" silicon lawset has been added to the pool of ion storm lawsets, as well as a currently unobtainable law board.