### PR TITLE
Make nuclear operative commander use HoS playtime for it's unlock

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -42,11 +42,11 @@
   setPreference: true
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:
-  - !type:OverallPlaytimeRequirement
-    time: 5h
   # Carpmosia-start - Antag playtimes
+  #  - !type:OverallPlaytimeRequirement
+  #    time: 5h
   - !type:RoleTimeRequirement
-    role: AntagNukeops
+    role: JobHeadOfSecurity
     time: 5h
   # Carpmosia-end - Antag playtimes
   guides: [ NuclearOperatives ]


### PR DESCRIPTION
## About the PR
Makes the Nuclear Operative Commander use Head of Security time for an unlock, instead of Nuclear Operative time.
Also removes the overall playtime requirement due to redundancy.

## Why / Balance
In the fallout of the nukeops time being merged, players have reached a consensus that it yields no tangible benefit & only impedes NukeOps rounds because currently Literally Nobody Has The Role Unlocked.
In discussions _before_ the nukeops time was merged players came to a conclusion that HoS time restrictions would be strictly better for the purpose it's trying to achieve, that is, the commander knowing how to lead a team into a firefight.

The general game playtime was removed for it's total redundancy, as HoS itself takes Many Times More to unlock.

## Technical details
Edits to yaml in the commander prototype.

## Media
<img width="848" height="88" alt="image" src="https://github.com/user-attachments/assets/b62bf754-6bda-4a8d-ba4d-6056508ad0c4" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Nuclear Operative Commander is now locked behind Head of Security playtime, instead of Nuclear Operative playtime.