### PR TITLE
Ticket magnitude change and fixes

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/Recipes/Lathes/sheet.yml
@@ -1,6 +1,7 @@
 - type: latheRecipe
   id: SheetSteel
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket10 # Carpmosia-edit - Ticket magnitude change
   result: SheetSteel1
   completetime: 0
   materials:
@@ -18,6 +19,7 @@
 - type: latheRecipe
   id: SheetGlass1
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket10 # Carpmosia-edit - Ticket magnitude change
   result: SheetGlass1
   completetime: 0
   materials:
@@ -44,6 +46,7 @@
 - type: latheRecipe
   id: SheetRGlassRaw
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket15 # Carpmosia-edit - Ticket magnitude change
   result: SheetRGlass1
   completetime: 0
   materials:
@@ -53,8 +56,6 @@
 
 - type: latheRecipe
   id: SheetRGlass30
-  printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
-  ticketProtoId: SalvageTicket50 # Carpmosia-edit - Starlight Salvage Tickets
   result: SheetRGlass
   completetime: 2
   materials:
@@ -65,6 +66,7 @@
 - type: latheRecipe
   id: SheetPGlass1
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket20 # Carpmosia-edit - Ticket magnitude change
   result: SheetPGlass1
   completetime: 0
   materials:
@@ -73,8 +75,6 @@
 
 - type: latheRecipe
   id: SheetPGlass30
-  printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
-  ticketProtoId: SalvageTicket50 # Carpmosia-edit - Starlight Salvage Tickets
   result: SheetPGlass
   completetime: 2
   materials:
@@ -84,6 +84,7 @@
 - type: latheRecipe
   id: SheetRPGlass1
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket25 # Carpmosia-edit - Ticket magnitude change
   result: SheetRPGlass1
   completetime: 0
   materials:
@@ -94,8 +95,6 @@
 
 - type: latheRecipe
   id: SheetRPGlass30
-  printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
-  ticketProtoId: SalvageTicket50 # Carpmosia-edit - Starlight Salvage Tickets
   result: SheetRPGlass
   completetime: 2
   materials:
@@ -107,6 +106,7 @@
 - type: latheRecipe
   id: SheetPlasma1
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket10 # Carpmosia-edit - Ticket magnitude change
   result: SheetPlasma1
   completetime: 0
   materials:
@@ -122,6 +122,7 @@
 - type: latheRecipe
   id: SheetPlasteel1
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket30 # Carpmosia-edit - Ticket magnitude change
   result: SheetPlasteel1
   completetime: 0
   materials:
@@ -131,8 +132,6 @@
 
 - type: latheRecipe
   id: SheetPlasteel30
-  printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
-  ticketProtoId: SalvageTicket50 # Carpmosia-edit - Starlight Salvage Tickets
   result: SheetPlasteel
   completetime: 5
   materials:
@@ -142,8 +141,6 @@
 
 - type: latheRecipe
   id: SheetUranium30
-  printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
-  ticketProtoId: SalvageTicket50 # Carpmosia-edit - Starlight Salvage Tickets
   result: SheetUranium
   completetime: 2
   materials:
@@ -152,6 +149,7 @@
 - type: latheRecipe
   id: SheetUGlass1
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket20 # Carpmosia-edit - Ticket magnitude change
   result: SheetUGlass1
   completetime: 0
   materials:
@@ -160,8 +158,6 @@
 
 - type: latheRecipe
   id: SheetUGlass30
-  printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
-  ticketProtoId: SalvageTicket50 # Carpmosia-edit - Starlight Salvage Tickets
   result: SheetUGlass
   completetime: 2
   materials:
@@ -171,6 +167,7 @@
 - type: latheRecipe
   id: SheetRUGlass1
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket25 # Carpmosia-edit - Ticket magnitude change
   result: SheetRUGlass1
   completetime: 0
   materials:
@@ -181,8 +178,6 @@
 
 - type: latheRecipe
   id: SheetRUGlass30
-  printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
-  ticketProtoId: SalvageTicket50 # Carpmosia-edit - Starlight Salvage Tickets
   result: SheetRUGlass
   completetime: 2
   materials:
@@ -193,8 +188,6 @@
 
 - type: latheRecipe
   id: IngotGold30
-  printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
-  ticketProtoId: SalvageTicket50 # Carpmosia-edit - Starlight Salvage Tickets
   result: IngotGold
   completetime: 2
   materials:
@@ -202,8 +195,6 @@
 
 - type: latheRecipe
   id: IngotSilver30
-  printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
-  ticketProtoId: SalvageTicket50 # Carpmosia-edit - Starlight Salvage Tickets
   result: IngotSilver
   completetime: 2
   materials:
@@ -211,7 +202,6 @@
 
 - type: latheRecipe
   id: MaterialBananium10
-  printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
   result: MaterialBananium
   completetime: 2
   materials:
@@ -220,7 +210,7 @@
 - type: latheRecipe
   id: MaterialDiamond
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
-  ticketProtoId: SalvageTicket100 # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket1000 # Carpmosia-edit - Starlight Salvage Tickets, Ticket magnitude change
   result: MaterialDiamond1
   completetime: 0
   materials:
@@ -229,6 +219,7 @@
 - type: latheRecipe
   id: SheetUranium1
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket10 # Carpmosia-edit - Ticket magnitude change
   result: SheetUranium1
   completetime: 0
   materials:
@@ -237,6 +228,7 @@
 - type: latheRecipe
   id: IngotGold1
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket10 # Carpmosia-edit - Ticket magnitude change
   result: IngotGold1
   completetime: 0
   materials:
@@ -245,6 +237,7 @@
 - type: latheRecipe
   id: IngotSilver1
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket10 # Carpmosia-edit - Ticket magnitude change
   result: IngotSilver1
   completetime: 0
   materials:
@@ -252,7 +245,6 @@
 
 - type: latheRecipe
   id: SheetPlastic
-  printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
   result: SheetPlastic1
   applyMaterialDiscount: false
   completetime: 0
@@ -262,6 +254,7 @@
 - type: latheRecipe
   id: MaterialBananium1
   printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
+  ticketProtoId: SalvageTicket10 # Carpmosia-edit - Ticket magnitude change
   result: MaterialBananium1
   completetime: 0
   materials:
@@ -269,7 +262,6 @@
 
 - type: latheRecipe
   id: MaterialSheetMeat
-  printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
   result: MaterialSheetMeat1
   completetime: 6.4
   materials:
@@ -277,7 +269,6 @@
 
 - type: latheRecipe
   id: SheetPaper
-  printTicket: true # Carpmosia-edit - Starlight Salvage Tickets
   result: SheetPaper1
   completetime: 1
   materials:

--- a/Resources/Prototypes/_Carpmosia/Catalog/VendingStores/salvage_store.yml
+++ b/Resources/Prototypes/_Carpmosia/Catalog/VendingStores/salvage_store.yml
@@ -3,7 +3,7 @@
   id: SalvageStorePickaxe
   productEntity: Pickaxe
   cost:
-    SalvageTicket: 20
+    SalvageTicket: 200
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -13,7 +13,7 @@
   id: SalvageStoreOreBag
   productEntity: OreBag
   cost:
-    SalvageTicket: 20
+    SalvageTicket: 200
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -23,7 +23,7 @@
   id: SalvageStoreBodyBag
   productEntity: BodyBag
   cost:
-    SalvageTicket: 40
+    SalvageTicket: 400
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -34,7 +34,7 @@
   description: A grappling hook that allows you to latch on to targets at a distance and pull yourself toward them. Perfect for salvaging in zero gravity.
   productEntity: WeaponGrapplingGun
   cost:
-    SalvageTicket: 40
+    SalvageTicket: 400
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -44,7 +44,7 @@
   id: SalvageStoreFultonBeacon
   productEntity: FultonBeacon
   cost:
-    SalvageTicket: 60
+    SalvageTicket: 600
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -56,7 +56,7 @@
   id: SalvageStoreFulton
   productEntity: Fulton
   cost:
-    SalvageTicket: 60
+    SalvageTicket: 600
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -68,7 +68,7 @@
   id: SalvageStoreSurvivalKnife
   productEntity: SurvivalKnife
   cost:
-    SalvageTicket: 40
+    SalvageTicket: 400
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -78,7 +78,7 @@
   id: SalvageStoreDoubleEmergencyOxygenTankFilled
   productEntity: DoubleEmergencyOxygenTankFilled
   cost:
-    SalvageTicket: 80
+    SalvageTicket: 800
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -90,7 +90,7 @@
   id: SalvageStoreDoubleEmergencyNitrogenTankFilled
   productEntity: DoubleEmergencyNitrogenTankFilled
   cost:
-    SalvageTicket: 80
+    SalvageTicket: 800
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -102,7 +102,7 @@
   id: SalvageStoreMineralScanner
   productEntity: MineralScanner
   cost:
-    SalvageTicket: 80
+    SalvageTicket: 800
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -112,7 +112,7 @@
   id: SalvageStoreClothingOuterHardsuitSpatio
   productEntity: ClothingOuterHardsuitSpatio
   cost:
-    SalvageTicket: 100
+    SalvageTicket: 1000
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -122,7 +122,7 @@
   id: SalvageStoreMiningDrill
   productEntity: MiningDrill
   cost:
-    SalvageTicket: 100
+    SalvageTicket: 1000
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -132,7 +132,7 @@
   id: SalvageStoreSeismicCharge
   productEntity: SeismicCharge
   cost:
-    SalvageTicket: 120
+    SalvageTicket: 1200
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -142,7 +142,7 @@
   id: SalvageStoreClothingOuterHardsuitSalvage
   productEntity: ClothingOuterHardsuitSalvage
   cost:
-    SalvageTicket: 250
+    SalvageTicket: 2500
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -153,7 +153,7 @@
   id: SalvageStoreFlareGun
   productEntity: WeaponFlareGun
   cost:
-    SalvageTicket: 20
+    SalvageTicket: 200
   categories:
   - SalvageStoreWeapons
   conditions:
@@ -167,7 +167,7 @@
     sprite: Objects/Weapons/Guns/Ammunition/Boxes/shotgun.rsi
     state: flare
   cost:
-    SalvageTicket: 20
+    SalvageTicket: 200
   categories:
   - SalvageStoreWeapons
   conditions:
@@ -177,7 +177,7 @@
   id: SalvageStoreWeaponCrusherDagger
   productEntity: WeaponCrusherDagger
   cost:
-    SalvageTicket: 100
+    SalvageTicket: 1000
   categories:
   - SalvageStoreWeapons
   conditions:
@@ -189,7 +189,7 @@
   id: SalvageStoreWeaponCrusherGlaive
   productEntity: WeaponCrusherGlaive
   cost:
-    SalvageTicket: 250
+    SalvageTicket: 2500
   categories:
   - SalvageStoreWeapons
   conditions:
@@ -201,7 +201,7 @@
   id: SalvageStoreWeaponCrusher
   productEntity: WeaponCrusher
   cost:
-    SalvageTicket: 300
+    SalvageTicket: 3000
   categories:
   - SalvageStoreWeapons
   conditions:
@@ -214,7 +214,7 @@
   id: SalvageStoreCigPackRed
   productEntity: CigPackRed
   cost:
-    SalvageTicket: 10
+    SalvageTicket: 100
   categories:
   - SalvageStoreConsumables
   conditions:
@@ -224,7 +224,7 @@
   id: SalvageStoreCigPackGreen
   productEntity: CigPackGreen
   cost:
-    SalvageTicket: 10
+    SalvageTicket: 100
   categories:
   - SalvageStoreConsumables
   conditions:
@@ -234,7 +234,7 @@
   id: SalvageStoreCigPackBlue
   productEntity: CigPackBlue
   cost:
-    SalvageTicket: 10
+    SalvageTicket: 100
   categories:
   - SalvageStoreConsumables
   conditions:
@@ -244,7 +244,7 @@
   id: SalvageStoreCigPackBlack
   productEntity: CigPackBlack
   cost:
-    SalvageTicket: 10
+    SalvageTicket: 100
   categories:
   - SalvageStoreConsumables
   conditions:
@@ -257,7 +257,7 @@
     sprite: Objects/Misc/module.rsi
     state: rndmajordisk
   cost:
-    SalvageTicket: 120
+    SalvageTicket: 1200
   categories:
   - SalvageStoreConsumables
   conditions:

--- a/Resources/Prototypes/_Carpmosia/Entities/Objects/Specific/Salvage/ticket.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Objects/Specific/Salvage/ticket.yml
@@ -38,6 +38,38 @@
 
 - type: entity
   parent: SalvageTicket
+  id: SalvageTicket15
+  suffix: 15
+  components:
+  - type: Stack
+    count: 15
+
+- type: entity
+  parent: SalvageTicket
+  id: SalvageTicket20
+  suffix: 20
+  components:
+  - type: Stack
+    count: 20
+
+- type: entity
+  parent: SalvageTicket
+  id: SalvageTicket25
+  suffix: 25
+  components:
+  - type: Stack
+    count: 25
+
+- type: entity
+  parent: SalvageTicket
+  id: SalvageTicket30
+  suffix: 30
+  components:
+  - type: Stack
+    count: 30
+
+- type: entity
+  parent: SalvageTicket
   id: SalvageTicket50
   suffix: 50
   components:
@@ -51,3 +83,19 @@
   components:
   - type: Stack
     count: 100
+
+- type: entity
+  parent: SalvageTicket
+  id: SalvageTicket500
+  suffix: 500
+  components:
+  - type: Stack
+    count: 500
+
+- type: entity
+  parent: SalvageTicket
+  id: SalvageTicket1000
+  suffix: 1000
+  components:
+  - type: Stack
+    count: 1000


### PR DESCRIPTION
## About the PR
Multiplies all ticket amounts by 10 and adjusts up some ore processor recipes to match the materials consumed. Removes ticket printing from unused recipes and non ore processor recipes.

## Why / Balance
Printing items like reinforced glass or especially plasteel should not be punished.
Tickets should not be sourced from the sheetifier.

## Technical details
Added ticket amount prototypes for 15, 20, 25, 30, 500, and 1000.
Added a ticketProtoId to every ticket printing recipe that lacked it, and modified the one used by diamonds.
Removed the printTicket and ticketProtoId from unused and non ore processor recipes.

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: All ticket amounts have been multiplied by 10.
- tweak: Ore processor recipes that consume more materials now produce more tickets.
- fix: Certain non ore processor recipes no longer print tickets.
