### PR TITLE
Updates to the Salvage Ticket Shop

### DIFF
--- a/Resources/Prototypes/_Carpmosia/Catalog/VendingStores/salvage_store.yml
+++ b/Resources/Prototypes/_Carpmosia/Catalog/VendingStores/salvage_store.yml
@@ -306,6 +306,6 @@
   cost:
     SalvageTicket: 10000
   categories:
-  - SalvageStoreVanityItems
+  - SalvageStoreFun
   conditions:
   - !type:BuyerAccessCondition

--- a/Resources/Prototypes/_Carpmosia/Catalog/VendingStores/salvage_store.yml
+++ b/Resources/Prototypes/_Carpmosia/Catalog/VendingStores/salvage_store.yml
@@ -152,7 +152,7 @@
   id: SalvageStoreVoidJetpack
   productEntity: JetpackVoidFilled
   cost:
-    SalvageTicket: 1800
+    SalvageTicket: 3600
   categories:
   - SalvageStoreEquipment
   conditions:

--- a/Resources/Prototypes/_Carpmosia/Catalog/VendingStores/salvage_store.yml
+++ b/Resources/Prototypes/_Carpmosia/Catalog/VendingStores/salvage_store.yml
@@ -41,6 +41,26 @@
   - !type:BuyerAccessCondition
 
 - type: listing
+  id: SalvageHandheldMassScanner
+  productEntity: HandHeldMassScanner
+  cost:
+    SalvageTicket: 400
+  categories:
+  - SalvageStoreEquipment
+  conditions:
+  - !type:BuyerAccessCondition
+
+- type: listing
+  id: SalvageStoreSurvivalKnife
+  productEntity: SurvivalKnife
+  cost:
+    SalvageTicket: 400
+  categories:
+  - SalvageStoreEquipment
+  conditions:
+  - !type:BuyerAccessCondition
+
+- type: listing
   id: SalvageStoreFultonBeacon
   productEntity: FultonBeacon
   cost:
@@ -62,16 +82,6 @@
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 3
-  - !type:BuyerAccessCondition
-
-- type: listing
-  id: SalvageStoreSurvivalKnife
-  productEntity: SurvivalKnife
-  cost:
-    SalvageTicket: 400
-  categories:
-  - SalvageStoreEquipment
-  conditions:
   - !type:BuyerAccessCondition
 
 - type: listing
@@ -139,10 +149,22 @@
   - !type:BuyerAccessCondition
 
 - type: listing
+  id: SalvageStoreVoidJetpack
+  productEntity: JetpackVoidFilled
+  cost:
+    SalvageTicket: 1800
+  categories:
+  - SalvageStoreEquipment
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 3
+  - !type:BuyerAccessCondition
+
+- type: listing
   id: SalvageStoreClothingOuterHardsuitSalvage
   productEntity: ClothingOuterHardsuitSalvage
   cost:
-    SalvageTicket: 2500
+    SalvageTicket: 3750
   categories:
   - SalvageStoreEquipment
   conditions:
@@ -174,10 +196,23 @@
   - !type:BuyerAccessCondition
 
 - type: listing
+  id: SalvageStorePKA
+  description: Forget yours? Remember, this weapon is your life.
+  productEntity: WeaponProtoKineticAccelerator
+  cost:
+    SalvageTicket: 600
+  categories:
+  - SalvageStoreWeapons
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 3
+  - !type:BuyerAccessCondition
+
+- type: listing
   id: SalvageStoreWeaponCrusherDagger
   productEntity: WeaponCrusherDagger
   cost:
-    SalvageTicket: 1000
+    SalvageTicket: 1500
   categories:
   - SalvageStoreWeapons
   conditions:
@@ -189,7 +224,7 @@
   id: SalvageStoreWeaponCrusherGlaive
   productEntity: WeaponCrusherGlaive
   cost:
-    SalvageTicket: 2500
+    SalvageTicket: 3750
   categories:
   - SalvageStoreWeapons
   conditions:
@@ -201,7 +236,7 @@
   id: SalvageStoreWeaponCrusher
   productEntity: WeaponCrusher
   cost:
-    SalvageTicket: 3000
+    SalvageTicket: 4500
   categories:
   - SalvageStoreWeapons
   conditions:
@@ -264,3 +299,13 @@
   - !type:BuyerAccessCondition
   - !type:ListingLimitedStockCondition
     stock: 1
+
+- type: listing
+  id: SalvageStoreSupremeSalvagerCloak
+  productEntity: ClothingNeckCloakSalvagerSupreme
+  cost:
+    SalvageTicket: 10000
+  categories:
+  - SalvageStoreVanityItems
+  conditions:
+  - !type:BuyerAccessCondition

--- a/Resources/Prototypes/_Carpmosia/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Structures/Machines/vending_machines.yml
@@ -34,6 +34,6 @@
     - SalvageStoreEquipment
     - SalvageStoreWeapons
     - SalvageStoreConsumables
-    - SalvageStoreVanityItems
+    - SalvageStoreFun
     currencyWhitelist:
     - SalvageTicket

--- a/Resources/Prototypes/_Carpmosia/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Structures/Machines/vending_machines.yml
@@ -34,5 +34,6 @@
     - SalvageStoreEquipment
     - SalvageStoreWeapons
     - SalvageStoreConsumables
+    - SalvageStoreVanityItems
     currencyWhitelist:
     - SalvageTicket

--- a/Resources/Prototypes/_Carpmosia/Store/categories.yml
+++ b/Resources/Prototypes/_Carpmosia/Store/categories.yml
@@ -10,3 +10,8 @@
 - type: storeCategory
   id: SalvageStoreConsumables
   name: Consumables
+
+- type: storeCategory
+  id: SalvageStoreVanityItems
+  name: Vanity
+

--- a/Resources/Prototypes/_Carpmosia/Store/categories.yml
+++ b/Resources/Prototypes/_Carpmosia/Store/categories.yml
@@ -12,6 +12,6 @@
   name: Consumables
 
 - type: storeCategory
-  id: SalvageStoreVanityItems
-  name: Vanity
+  id: SalvageStoreFunItems
+  name: Fun
 

--- a/Resources/Prototypes/_Carpmosia/Store/categories.yml
+++ b/Resources/Prototypes/_Carpmosia/Store/categories.yml
@@ -12,6 +12,6 @@
   name: Consumables
 
 - type: storeCategory
-  id: SalvageStoreFunItems
+  id: SalvageStoreFun
   name: Fun
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Increases the price of the crusher weaponry and the mining hardsuit. Adds Mass Scanners and PKAs to the listings, as well as two items still missing from the job board rewards: void jetpacks and the Supreme Salvager's Cloak. Adds a new Fun category which currently only has the cloak.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Feedback has been good on the ticket machine, with some caveats: 

- With more than one salvager working, its a bit too easy to buy out the contents of the ticket machine too early into the shift. To help combat this, the prices of the currently most sought-after items (the crusher weaponry and the mining hardsuits) were increased by %50. I'm hesitant to increase prices too much at once, but I think this should be *fine* to incentivize mining just a bit more before you are all fully geared out with suits and crushers.

- There is a lack of high-end items to incentivize continued mining later in the shift. This is something that is going to need more dev-time to fully address, but re-adding the Supreme Salvager's Cloak gives an expensive vanity option that at least *some* salvagers will want to mine for. The new category gives us a place to put similar items we had talked about but haven't implemented yet, like the .

- Some items were simply missing from the machine that made sense. In particular, the afformentioned cloak, as well as the Void Jetpack (they would normally be rewarded by the defunct job board) the PKA(in case you lose yours) and the Mass Scanner (doesn't have much of a use case in the current balance of salvage on carp given the Shuttle, but hey, it makes sense).
 
## Technical details
<!-- Summary of code changes for easier review. -->
All changes are in .yml.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The Salvage Ticket Vendor now has listings for PKAs, Handheld Mass Scanners, Void Jetpacks, and the Supreme Salvager's Cape!
- tweak: Increased the ticket prices of the Mining Hardsuit and all Crusher Weaponry in the Salvage Shop.

