### PR TITLE
Unnerf plushie fights

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/plushies.yml
@@ -19,9 +19,9 @@
   - type: EmitSoundOnTrigger
     sound: *BasePlushieSound
   - type: UseDelay
-    delay: 3.0
+    delay: 1.0 # Carpmosia-edit - Unnerf plushie fights
   - type: MeleeWeapon
-    attackRate: 0.333
+    attackRate: 1 # Carpmosia-edit - Unnerf plushie fights
     wideAnimationRotation: 180
     soundHit: *BasePlushieSound
     damage:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed use and attack cooldowns on plushies from 3 seconds to 1 second.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
3 second delay is unreasonably long delay when you are beating your friend with a shark plushie

## Technical details
<!-- Summary of code changes for easier review. -->
Two lines of YAML

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Atakku
- tweak: Reduced swing and use delay on plushies from 3 seconds to 1
