### PR TITLE
Allow pipe stacking for most binary devices

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -6,9 +6,11 @@
     mode: SnapgridCenter
   components:
   - type: AtmosDevice
-  - type: Tag
-    tags:
-      - Unstackable
+  # Carpmosia-start - Atmos stacking
+  # - type: Tag
+  #   tags:
+  #     - Unstackable
+  # Carpmosia-end - Atmos stacking
   - type: SubFloorHide
     blockInteractions: false
     blockAmbience: false
@@ -437,6 +439,11 @@
   placement:
     mode: AlignAtmosPipeLayers # Carpmosia-edit - Atmos Alt Prototypes
   components:
+    # Carpmosia-start - Atmos stacking
+    - type: Tag
+      tags:
+        - Unstackable
+    # Carpmosia-end - Atmos stacking
     - type: SubFloorHide
       visibleLayers:
       - enum.SubfloorLayers.FirstLayer
@@ -641,6 +648,11 @@
   placement:
     mode: SnapgridCenter
   components:
+  # Carpmosia-start - Atmos stacking
+  - type: Tag
+    tags:
+      - Unstackable
+  # Carpmosia-end - Atmos stacking
   - type: Rotatable
   - type: Transform
     noRot: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Allowed pipe stacking for:
- pressure pumps
- volumetric pumps
- pressure regulators
- passive gates
- manual valves
- signal valves

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Makes no sense as to why we can't have multiple devices in one tile (on different layers). This fixes that.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed `Unstackable` tag from GasBinaryBase, added it for GasPort and HeatExchanger

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Most binary atmos devices can now be stacked along on a single tile