### PR TITLE
Medical tourniquets

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/job.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/job.yml
@@ -173,10 +173,12 @@
       - Wrench
       - Bottle
       - Spray
-      - Brutepack
-      - Bloodpack
-      - Gauze
-      - Ointment
+      # Carpmosia-edit - Medical tourniquets
+      #- Brutepack
+      #- Bloodpack
+      #- Gauze
+      #- Ointment
+      # Carpmosia-edit - Medical tourniquets
       - CigPack
       - PillCanister
       - Radio
@@ -189,6 +191,7 @@
       - Injector
       - Pill
       - HandLabeler
+      - Healing # Carpmosia-edit - Medical tourniquets
   - type: ItemMapper
     sprite: *BeltOverlay
     mapLayers:

--- a/Resources/Prototypes/Entities/Clothing/Belt/job.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/job.yml
@@ -173,12 +173,12 @@
       - Wrench
       - Bottle
       - Spray
-      # Carpmosia-edit - Medical tourniquets
+      # Carpmosia-start - Medical tourniquets
       #- Brutepack
       #- Bloodpack
       #- Gauze
       #- Ointment
-      # Carpmosia-edit - Medical tourniquets
+      # Carpmosia-end - Medical tourniquets
       - CigPack
       - PillCanister
       - Radio

--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -6,6 +6,7 @@
   - Brutepack
   - Ointment
   - Gauze
+  - Tourniquet # Carpmosia-edit - Medical tourniquets
 
 - type: latheRecipePack
   id: BasicChemistryStatic

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -170,17 +170,6 @@
     Plastic: 200
     Steel: 100
 
-# Carpmosia-start - Better tourniquets
-- type: latheRecipe
-  parent: BaseToolRecipe
-  id: Tourniquet
-  result: Tourniquet1
-  completetime: 1.5
-  materials:
-    Plastic: 25
-    Steel: 10
-# Carpmosia-end - Better tourniquets
-
 ## Weapons
 
 # Melee

--- a/Resources/Prototypes/_Carpmosia/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Carpmosia/Recipes/Lathes/medical.yml
@@ -4,3 +4,11 @@
   completetime: 2
   materials:
     Steel: 250
+
+- type: latheRecipe
+  id: Tourniquet
+  result: Tourniquet1
+  completetime: 1
+  materials:
+    Plastic: 25
+    Steel: 10


### PR DESCRIPTION
## About the PR
Adds tourniquets to the medical techfab and allows them in medical belts, as well as slightly deceasing their craft time.

## Why / Balance
Medical already gets tourniquets roundstart in the nanomed plus.

## Technical details
Added tourniquet recipe to TopicalsStatic.
Moved tourniquet recipe from Recipes/Lathes/security.yml to _Carpmosia/Recipes/Lathes/medical.yml, reduced completion time to match other topicals and removed parent.
Made ClothingBeltMedical whitelist the Healing component instead of individual tags (technically allows healing toolboxes as well but those are only used in deathmatch).

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: The tourniquet recipe is now also available in the medical techfab.
- tweak: Tourniquets now fit in medical belts.
- tweak: Tourniquets take 33% less time to make.
