### PR TITLE
Move Carpmosia specific StorageFills to EntityTableContainerFills

### DIFF
--- a/Resources/Prototypes/_Carpmosia/Catalog/Fills/Backpacks/satchel.yml
+++ b/Resources/Prototypes/_Carpmosia/Catalog/Fills/Backpacks/satchel.yml
@@ -5,7 +5,7 @@
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:AllSelector
+      storagebase: !type:AllSelector
         children:
         - id: ToolDebug
         - id: WelderExperimental

--- a/Resources/Prototypes/_Carpmosia/Catalog/Fills/Backpacks/satchel.yml
+++ b/Resources/Prototypes/_Carpmosia/Catalog/Fills/Backpacks/satchel.yml
@@ -3,10 +3,12 @@
   parent: ClothingBackpackSatchelHolding
   suffix: Filled, Centcom Formal, Admeme
   components:
-  - type: StorageFill
-    contents:
-      - id: ToolDebug
-      - id: WelderExperimental
-      - id: RCDExperimental
-      - id: Multitool
-      - id: BoxSurvival
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: ToolDebug
+        - id: WelderExperimental
+        - id: RCDExperimental
+        - id: Multitool
+        - id: BoxSurvival

--- a/Resources/Prototypes/_Carpmosia/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/_Carpmosia/Catalog/Fills/Crates/engineering.yml
@@ -4,9 +4,10 @@
   name: thermo-electric generator crate
   description: 1 thermo-electric generator flatpack and 2 circulator flatpacks.
   components:
-  - type: StorageFill
-    contents:
-    - id: TegFlatpack
-      amount: 1
-    - id: CirculatorFlatpack
-      amount: 2
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: TegFlatpack
+        - id: CirculatorFlatpack
+          amount: 2

--- a/Resources/Prototypes/_Carpmosia/Catalog/Fills/Crates/science.yml
+++ b/Resources/Prototypes/_Carpmosia/Catalog/Fills/Crates/science.yml
@@ -1,9 +1,10 @@
-  - type: entity
-    id: CrateR&DServer
-    parent: CrateScienceSecure
-    name: R&D Server
-    description: The central hub for all research activities on the station. Contains a Research and Development Server.
-    components:
-    - type: StorageFill
-      contents:
-      - id: ResearchAndDevelopmentServer
+- type: entity
+  id: CrateR&DServer
+  parent: CrateScienceSecure
+  name: R&D Server
+  description: The central hub for all research activities on the station. Contains a Research and Development Server.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage:
+        id: ResearchAndDevelopmentServer


### PR DESCRIPTION
## About the PR
Replaces Carpmosia specific StorageFills with EntityTableContainerFills.

## Why / Balance
StoargeFills are to be removed upstream.

## Technical details
Carpmosia specific StorageFills have been replaced with EntityTableContainerFills, indentation on them has been changed.
A redundant `amount: 1` has been removed.

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
