### PR TITLE
Genericise Undetermined Thieves Tools

### DIFF
--- a/Content.Client/Thief/ThiefBackpackMenu.xaml
+++ b/Content.Client/Thief/ThiefBackpackMenu.xaml
@@ -1,7 +1,7 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
 						xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
 						xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-						Title="{Loc 'thief-backpack-window-title'}"
+						<!-- Carpmosia-edit - Genericise Undetermined Tools Title="{Loc 'thief-backpack-window-title'}" -->
 						MinSize="700 700">
 	<BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
 		<!-- First Informational panel -->
@@ -25,7 +25,7 @@
 				</BoxContainer>
 			</ScrollContainer>
 		</PanelContainer>
-		
+
 		<!-- Third approve button panel -->
 		<PanelContainer Margin="10">
 			<Button Name="ApproveButton"

--- a/Content.Client/Thief/ThiefBackpackMenu.xaml
+++ b/Content.Client/Thief/ThiefBackpackMenu.xaml
@@ -1,7 +1,6 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
 						xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
 						xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-						<!-- Carpmosia-edit - Genericise Undetermined Tools Title="{Loc 'thief-backpack-window-title'}" -->
 						MinSize="700 700">
 	<BoxContainer Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True">
 		<!-- First Informational panel -->

--- a/Content.Client/Thief/ThiefBackpackMenu.xaml.cs
+++ b/Content.Client/Thief/ThiefBackpackMenu.xaml.cs
@@ -46,8 +46,8 @@ public sealed partial class ThiefBackpackMenu : FancyWindow
                 selectedNumber++;
         }
 
-        Title = Loc.GetString(state.ToolsName); // Carpmosia edit - Genericise Undetermined Tools
-        Description.Text = Loc.GetString(state.ToolsDesc, ("maxCount", state.MaxSelectedSets)); // Carpmosia edit - Genericise Undetermined Tools
+        Title = Loc.GetString(state.ToolName); // Carpmosia edit - Genericise Undetermined Tools
+        Description.Text = Loc.GetString(state.ToolDesc, ("maxCount", state.MaxSelectedSets)); // Carpmosia edit - Genericise Undetermined Tools
         SelectedSets.Text = Loc.GetString("thief-backpack-window-selected", ("selectedCount", selectedNumber), ("maxCount", state.MaxSelectedSets));
         ApproveButton.Disabled = selectedNumber != state.MaxSelectedSets;
     }

--- a/Content.Client/Thief/ThiefBackpackMenu.xaml.cs
+++ b/Content.Client/Thief/ThiefBackpackMenu.xaml.cs
@@ -46,7 +46,8 @@ public sealed partial class ThiefBackpackMenu : FancyWindow
                 selectedNumber++;
         }
 
-        Description.Text = Loc.GetString("thief-backpack-window-description", ("maxCount", state.MaxSelectedSets));
+        Title = Loc.GetString(state.ToolsName); // Carpmosia edit - Genericise Undetermined Tools
+        Description.Text = Loc.GetString(state.ToolsDesc, ("maxCount", state.MaxSelectedSets)); // Carpmosia edit - Genericise Undetermined Tools
         SelectedSets.Text = Loc.GetString("thief-backpack-window-selected", ("selectedCount", selectedNumber), ("maxCount", state.MaxSelectedSets));
         ApproveButton.Disabled = selectedNumber != state.MaxSelectedSets;
     }

--- a/Content.Server/Thief/Components/ThiefUndeterminedBackpackComponent.cs
+++ b/Content.Server/Thief/Components/ThiefUndeterminedBackpackComponent.cs
@@ -30,6 +30,20 @@ public sealed partial class ThiefUndeterminedBackpackComponent : Component
     [DataField]
     public int MaxSelectedSets = 2;
 
+    // Carpmosia start - Genericise Undetermined Tools
+    /// <summary>
+    /// Title field for undetermined equipment ui.
+    /// </summary>
+    [DataField]
+    public string ToolsName = "thief-backpack-window-title";
+
+    /// <summary>
+    /// Description field for undetermined equipment ui.
+    /// </summary>
+    [DataField]
+    public string ToolsDesc = "thief-backpack-window-description";
+    // Carpmosia end - Genericise Undetermined Tools
+
     /// <summary>
     /// What entity all the spawned items will appear inside of
     /// If null, will instead drop on the ground.

--- a/Content.Server/Thief/Components/ThiefUndeterminedBackpackComponent.cs
+++ b/Content.Server/Thief/Components/ThiefUndeterminedBackpackComponent.cs
@@ -35,13 +35,13 @@ public sealed partial class ThiefUndeterminedBackpackComponent : Component
     /// Title field for undetermined equipment ui.
     /// </summary>
     [DataField]
-    public string ToolsName = "thief-backpack-window-title";
+    public string ToolName = "thief-backpack-window-title";
 
     /// <summary>
     /// Description field for undetermined equipment ui.
     /// </summary>
     [DataField]
-    public string ToolsDesc = "thief-backpack-window-description";
+    public string ToolDesc = "thief-backpack-window-description";
     // Carpmosia end - Genericise Undetermined Tools
 
     /// <summary>

--- a/Content.Server/Thief/Components/ThiefUndeterminedBackpackComponent.cs
+++ b/Content.Server/Thief/Components/ThiefUndeterminedBackpackComponent.cs
@@ -35,13 +35,13 @@ public sealed partial class ThiefUndeterminedBackpackComponent : Component
     /// Title field for undetermined equipment ui.
     /// </summary>
     [DataField]
-    public string ToolName = "thief-backpack-window-title";
+    public LocId ToolName = "thief-backpack-window-title";
 
     /// <summary>
     /// Description field for undetermined equipment ui.
     /// </summary>
     [DataField]
-    public string ToolDesc = "thief-backpack-window-description";
+    public LocId ToolDesc = "thief-backpack-window-description";
     // Carpmosia end - Genericise Undetermined Tools
 
     /// <summary>

--- a/Content.Server/Thief/Systems/ThiefUndeterminedBackpackSystem.cs
+++ b/Content.Server/Thief/Systems/ThiefUndeterminedBackpackSystem.cs
@@ -96,6 +96,6 @@ public sealed class ThiefUndeterminedBackpackSystem : EntitySystem
             data.Add(i, info);
         }
 
-        _ui.SetUiState(uid, ThiefBackpackUIKey.Key, new ThiefBackpackBoundUserInterfaceState(data, component.MaxSelectedSets, component.ToolsName, component.ToolsDesc)); // Carpmosia edit - Genericise Undetermined Tools
+        _ui.SetUiState(uid, ThiefBackpackUIKey.Key, new ThiefBackpackBoundUserInterfaceState(data, component.MaxSelectedSets, component.ToolName, component.ToolDesc)); // Carpmosia edit - Genericise Undetermined Tools
     }
 }

--- a/Content.Server/Thief/Systems/ThiefUndeterminedBackpackSystem.cs
+++ b/Content.Server/Thief/Systems/ThiefUndeterminedBackpackSystem.cs
@@ -96,6 +96,6 @@ public sealed class ThiefUndeterminedBackpackSystem : EntitySystem
             data.Add(i, info);
         }
 
-        _ui.SetUiState(uid, ThiefBackpackUIKey.Key, new ThiefBackpackBoundUserInterfaceState(data, component.MaxSelectedSets));
+        _ui.SetUiState(uid, ThiefBackpackUIKey.Key, new ThiefBackpackBoundUserInterfaceState(data, component.MaxSelectedSets, component.ToolsName, component.ToolsDesc)); // Carpmosia edit - Genericise Undetermined Tools
     }
 }

--- a/Content.Shared/Thief/Components/ThiefBackpackUI.cs
+++ b/Content.Shared/Thief/Components/ThiefBackpackUI.cs
@@ -10,16 +10,16 @@ public sealed class ThiefBackpackBoundUserInterfaceState : BoundUserInterfaceSta
     public int MaxSelectedSets;
 
     // Carpmosia start - Genericise Undetermined Tools
-    public string ToolsName;
-    public string ToolsDesc;
+    public string ToolName;
+    public string ToolDesc;
     // Carpmosia end - Genericise Undetermined Tools
-    public ThiefBackpackBoundUserInterfaceState(Dictionary<int, ThiefBackpackSetInfo> sets, int max, string toolsName, string toolsDesc)
+    public ThiefBackpackBoundUserInterfaceState(Dictionary<int, ThiefBackpackSetInfo> sets, int max, string toolName, string toolDesc)
     {
         Sets = sets;
         MaxSelectedSets = max;
         // Carpmosia start - Genericise Undetermined Tools
-        ToolsName = toolsName;
-        ToolsDesc = toolsDesc;
+        ToolName = toolName;
+        ToolDesc = toolDesc;
         // Carpmosia end - Genericise Undetermined Tools
     }
 }

--- a/Content.Shared/Thief/Components/ThiefBackpackUI.cs
+++ b/Content.Shared/Thief/Components/ThiefBackpackUI.cs
@@ -9,10 +9,18 @@ public sealed class ThiefBackpackBoundUserInterfaceState : BoundUserInterfaceSta
     public readonly Dictionary<int, ThiefBackpackSetInfo> Sets;
     public int MaxSelectedSets;
 
-    public ThiefBackpackBoundUserInterfaceState(Dictionary<int, ThiefBackpackSetInfo> sets, int max)
+    // Carpmosia start - Genericise Undetermined Tools
+    public string ToolsName;
+    public string ToolsDesc;
+    // Carpmosia end - Genericise Undetermined Tools
+    public ThiefBackpackBoundUserInterfaceState(Dictionary<int, ThiefBackpackSetInfo> sets, int max, string toolsName, string toolsDesc)
     {
         Sets = sets;
         MaxSelectedSets = max;
+        // Carpmosia start - Genericise Undetermined Tools
+        ToolsName = toolsName;
+        ToolsDesc = toolsDesc;
+        // Carpmosia end - Genericise Undetermined Tools
     }
 }
 

--- a/Content.Shared/Thief/Components/ThiefBackpackUI.cs
+++ b/Content.Shared/Thief/Components/ThiefBackpackUI.cs
@@ -8,10 +8,9 @@ public sealed class ThiefBackpackBoundUserInterfaceState : BoundUserInterfaceSta
 {
     public readonly Dictionary<int, ThiefBackpackSetInfo> Sets;
     public int MaxSelectedSets;
-
     // Carpmosia start - Genericise Undetermined Tools
-    public string ToolName;
-    public string ToolDesc;
+    public LocId ToolName;
+    public LocId ToolDesc;
     // Carpmosia end - Genericise Undetermined Tools
     public ThiefBackpackBoundUserInterfaceState(Dictionary<int, ThiefBackpackSetInfo> sets, int max, string toolName, string toolDesc)
     {

--- a/Resources/Locale/en-US/_Carpmosia/ert/backpack.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/ert/backpack.ftl
@@ -1,0 +1,9 @@
+ert-backpack-window-title = ERT Loadout
+ert-cburn-backpack-window-title = CBurn Loadout
+
+ert-backpack-window-description =
+    Inside are your tools of the trade, which will dissolve when you're ready.
+    Choose {$maxCount} different {$maxCount ->
+        [1] set
+        *[other] sets
+    } from the list.

--- a/Resources/Prototypes/_Carpmosia/Catalog/ert_gear_sets.yml
+++ b/Resources/Prototypes/_Carpmosia/Catalog/ert_gear_sets.yml
@@ -1,0 +1,61 @@
+- type: thiefBackpackSet
+  id: ERTPointmanSet
+  name: ERT Pointman Set
+  description: A loadout for rushing headfirst into danger. Comes with an Enforcer, a box of shells, slugs, and two syringes of ephedrine.
+  sprite:
+    sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
+    state: icon
+  content:
+  - WeaponShotgunEnforcer
+  - BoxLethalshot
+  - BoxShotgunSlug
+  - SyringeEphedrine
+  - SyringeEphedrine
+
+- type: thiefBackpackSet
+  id: ERTRiflemanSet
+  name: ERT Rifleman Set
+  description: A basic and effective set of gear. Comes with a Lecter, four full magazines of .20 rifle ammunition, and two stinger grenades.
+  sprite:
+    sprite: Objects/Weapons/Guns/Rifles/lecter.rsi
+    state: icon
+  content:
+  - WeaponRifleLecter
+  - BoxMagazineRifle
+  - GrenadeStinger
+  - GrenadeStinger
+
+- type: thiefBackpackSet
+  id: ERTCombatTechnicianSet
+  name: ERT Combat Technician Set
+  description: Equipment for breaking through or building fortifications. Comes with a Drozd, two submachinegun magazines, and a suite of advanced tools.
+  sprite:
+    sprite: Objects/Weapons/Guns/SMGs/drozd.rsi
+    state: icon
+  content:
+  - WeaponSubMachineGunDrozd
+  - MagazinePistolSubMachineGun
+  - MagazinePistolSubMachineGun
+  - PowerDrill
+  - JawsOfLife
+  - WelderExperimental
+  - Multitool
+  - HolofanProjector
+  - GasAnalyzer
+  - trayScanner
+  - ClothingEyesGlassesMeson
+
+- type: thiefBackpackSet
+  id: ERTFieldMedicSet
+  name: ERT Field Medic Set
+  description: Help keep the crew alive, at the expense of your personal firepower. Comes with a combat medkit, a compact defibrillator, two bottles of epinephrine, a syringe, and a svalinn laser pistol.
+  sprite:
+    sprite: Objects/Specific/Medical/firstaidkits.rsi
+    state: blackkit
+  content:
+  - WeaponLaserSvalinn
+  - MedkitCombatFilled
+  - DefibrillatorCompact
+  - ChemistryBottleEpinephrine
+  - ChemistryBottleEpinephrine
+  - Syringe

--- a/Resources/Prototypes/_Carpmosia/Entities/Objects/Tools/ert.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Objects/Tools/ert.yml
@@ -15,8 +15,8 @@
     - ERTFieldMedicSet
     spawnedStoragePrototype: ClothingBackpackDuffel
     maxSelectedSets: 1
-    toolsName: "ert-backpack-window-title"
-    toolsDesc: "ert-backpack-window-description"
+    toolName: "ert-backpack-window-title"
+    toolDesc: "ert-backpack-window-description"
   - type: ActivatableUI
     key: enum.ThiefBackpackUIKey.Key
   - type: UserInterface

--- a/Resources/Prototypes/_Carpmosia/Entities/Objects/Tools/ert.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Objects/Tools/ert.yml
@@ -1,0 +1,25 @@
+- type: entity
+  id: DuffelERT
+  name: undetermined ERT duffel
+  description: This is where your favorite supplies lie. Try to remember which ones.
+  parent: [ BaseItem, BaseCentcommContraband ]
+  components:
+  - type: Sprite
+    sprite: Clothing/Back/Satchels/smuggler.rsi
+    state: folded
+  - type: ThiefUndeterminedBackpack
+    possibleSets:
+    - ERTRiflemanSet
+    - ERTPointmanSet
+    - ERTCombatTechnicianSet
+    - ERTFieldMedicSet
+    spawnedStoragePrototype: ClothingBackpackDuffel
+    maxSelectedSets: 1
+    toolsName: "ert-backpack-window-title"
+    toolsDesc: "ert-backpack-window-description"
+  - type: ActivatableUI
+    key: enum.ThiefBackpackUIKey.Key
+  - type: UserInterface
+    interfaces:
+      enum.ThiefBackpackUIKey.Key:
+        type: ThiefBackpackBoundUserInterface


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added two fields to the undetermined thieves tools component to let us change the name and description in the UI for undetermined tools. Added a new 'undetermined ERT duffel' which uses the undetermined thieves tool component with the new fields. The undetermined thieving satchel should be unchanged.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This lets us make new undetermined toolsets for different purposes with their own flavoring with minimal effort. Part of an overhaul to ERT Sec and ERT CBurn I've been working on, but it also just opens up neat new uses for the ThiefUndeterminedBackpack component. 

Some relevance to https://github.com/carpmosia/carpmosia/issues/88.
## Technical details
<!-- Summary of code changes for easier review. -->
Added ToolsName and ToolsDesc fields to the ThiefUndeterminedBackpack component. Updated the constructor for ThiefBackpackBoundUserInterfaceState and it's use in ThiefUndeterminedBackpackSystem to use the new fields for the title and description of the UI. Added a yaml prototype for an undetermined ERT duffel bag (pending spritework). Added a few prototypes for gear sets for the undetermined ERT duffel bag.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="431" height="255" alt="image" src="https://github.com/user-attachments/assets/a71336a3-4d65-46b4-9519-1c6e43464b8a" />
<img width="702" height="805" alt="image" src="https://github.com/user-attachments/assets/d314ca3d-e47e-4e7e-ad69-3c105b6098da" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
ThiefBackpackBoundUserInterfaceState's constructor has been updated to let us set the description and title in the UI per undetermined gear prototype. It's not used anywhere else, but hypothetically if it gets used anywhere else in the future, we'll need to come back and figure something else out.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
