### PR TITLE
Minor yaml tweaks and a full stop for koi

### DIFF
--- a/Resources/Prototypes/_Carpmosia/Catalog/Fills/Crates/npc.yml
+++ b/Resources/Prototypes/_Carpmosia/Catalog/Fills/Crates/npc.yml
@@ -8,5 +8,4 @@
     containers:
       entity_storage: !type:NestedSelector
         tableId: RandomKoiTable
-        rolls: !type:ConstantNumberSelector
-          value: 3
+        rolls: 3

--- a/Resources/Prototypes/_Carpmosia/Entities/Markers/Spawners/koi.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Markers/Spawners/koi.yml
@@ -17,17 +17,11 @@
   id: RandomKoiTable
   table: !type:GroupSelector
     children:
-    - !type:GroupSelector
-      weight: 10
-      children:
-      - id: MobRedCircleKoi
-      - id: MobRedBlackKoi
-    - !type:GroupSelector
-      weight: 3
-      children:
-      - id: MobGoldBlackKoi
-      - id: MobBloodSkeletonKoi
-    - !type:GroupSelector
-      weight: 1
-      children:
-      - id: MobSpaceGlowKoi
+    - id: MobRedCircleKoi
+    - id: MobRedBlackKoi
+    - id: MobGoldBlackKoi
+      weight: 0.3
+    - id: MobBloodSkeletonKoi
+      weight: 0.3
+    - id: MobSpaceGlowKoi
+      weight: 0.2

--- a/Resources/Prototypes/_Carpmosia/Entities/Mobs/NPCs/koi.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Mobs/NPCs/koi.yml
@@ -2,7 +2,7 @@
   name: space koi
   id: BaseMobKoi
   parent: BaseMobCarp
-  description: Result of hundreds of years of selective breeding and genetic engineering, a friendly and colourful variant of the common space carp
+  description: Result of hundreds of years of selective breeding and genetic engineering, a friendly and colourful variant of the common space carp.
   abstract: true
   components:
     - type: HTN


### PR DESCRIPTION
## About the PR
Some yaml tweaks and adds a full stop where one was missing.

## Why / Balance
Descriptions are to end will full stops.
Serialiser can infer ConstantNumberSelector and RangeNumberSelector.
Chances look more readable to me like this. Weight of 1 is the default, and doesn't need to be specified.

## Technical details
Added a full stop to the space koi description, messed with yaml formatting without changing any of the effects.

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
