### PR TITLE
More minor tweaks and fixes for space Koi

### DIFF
--- a/Resources/Prototypes/_Carpmosia/Catalog/Fills/Crates/npc.yml
+++ b/Resources/Prototypes/_Carpmosia/Catalog/Fills/Crates/npc.yml
@@ -2,7 +2,7 @@
   id: CrateNPCSpaceKoi
   parent: CrateLivestock
   name: space koi crate
-  description: A crate containing five space kois.
+  description: A crate containing three space koi.
   components:
   - type: EntityTableContainerFill
     containers:

--- a/Resources/Prototypes/_Carpmosia/Entities/Mobs/NPCs/koi.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Mobs/NPCs/koi.yml
@@ -5,39 +5,41 @@
   description: Result of hundreds of years of selective breeding and genetic engineering, a friendly and colourful variant of the common space carp.
   abstract: true
   components:
-    - type: HTN
-      rootTask:
-        task: IdleCompound
-    - type: NpcFactionMember
-      factions:
-      - SimpleNeutral
-    - type: Sprite
-      drawdepth: Mobs
-      sprite: _Carpmosia/Mobs/Animals/Koi/gold_black.rsi
-      layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-    - type: DamageStateVisuals
-      states:
-        Alive:
-          Base: alive
-        Dead:
-          Base: dead
-    - type: Butcherable
-      spawned:
-        - id: FoodMeat
-          amount: 1
-    - type: MeleeWeapon # Make sure koi can't break glass
-      damage:
-        types:
-          Slash: 5
-    # Remove Carp tag to avoid cheezing bounty
-    - type: Tag
-      tags:
-        - DoorBumpOpener
-        - CannotSuicide
-    - type: StaticPrice
-      price: -800
+  - type: HTN
+    rootTask:
+      task: SimpleHostileCompound
+  - type: NpcFactionMember
+    factions:
+    - Passive
+  - type: NPCRetaliation
+    attackMemoryLength: 10
+  - type: Sprite
+    drawdepth: Mobs
+    sprite: _Carpmosia/Mobs/Animals/Koi/gold_black.rsi
+    layers:
+    - map: [ "enum.DamageStateVisualLayers.Base" ]
+      state: alive
+  - type: DamageStateVisuals
+    states:
+      Alive:
+        Base: alive
+      Dead:
+        Base: dead
+  - type: Butcherable
+    spawned:
+    - id: FoodMeat
+      amount: 1
+  - type: MeleeWeapon # Make sure koi can't break glass
+    damage:
+      types:
+        Piercing: 5
+  # Remove Carp tag to avoid cheezing bounty
+  - type: Tag
+    tags:
+    - DoorBumpOpener
+    - CannotSuicide
+  - type: StaticPrice
+    price: -800
 
 - type: entity
   parent: BaseMobKoi


### PR DESCRIPTION
## About the PR
More fixes for #160, the consequences of pushing last minute for more on stable.

## Why / Balance
Space koi are supposed to be unable harm station integrity, and were supposed to fight back when attacked. Incorrect plural was noticed but forgotten to push, and amount in the CrateNPCSpaceKoi description was never updated for the changes to its fill.

## Technical details
Indentation on BaseMobKoi adjusted to minimum, root task changed from IdleCompound to SimpleHostileCompound, added NPCRetaliation with a memory length of 10, changed faction to passive, switched damage from slash to piercing

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Space koi will now retaliate when attacked.
- fix: Space koi crate now states the correct amount of koi and uses the correct plural of koi.
- fix: Space koi can no longer break grilles.
