### PR TITLE
Replace unarmored winter coat in SecDrobe inventory

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
@@ -17,7 +17,7 @@
     ClothingUniformJumpskirtSecGrey: 3
     ClothingUniformJumpsuitSecBlue: 3
     ClothingHeadsetSecurity: 3
-    ClothingOuterWinterSec: 2
+    ClothingOuterWinterSecArmored: 2 # Carpmosia-edit - Armored winter coats
     ClothingOuterArmorBasic: 2
     ClothingNeckScarfStripedRed: 3
     ClothingOuterArmorBasicSlim: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title

## Why / Balance
The unarmored winter coat is absoleate and is otherwise inacesable during the round

## Technical details
Swaps the security winter coat with its armored variant in SecDrobe



## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.




**Changelog**

:cl:
- tweak: The SecDrobe now holds armored winter coats, instead of unarmored ones.

