### PR TITLE
Restrict Snowball Station's Player Count Requirements

### DIFF
--- a/Resources/Prototypes/Maps/snowball.yml
+++ b/Resources/Prototypes/Maps/snowball.yml
@@ -2,8 +2,8 @@
   id: Snowball
   mapName: 'Snowball Station'
   mapPath: /Maps/snowball.yml
-  minPlayers: 15
-  maxPlayers: 50
+  minPlayers: 5 # Carpmosia-edit - Snowball is not high-pop
+  maxPlayers: 30 # Carpmosia-edit - Snowball is not high-pop
   stations:
     Snowball:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adjusted Snowball's minimum and maximum player requirements to 5 and 30 respectively, instead of 15 to 50.


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Snowball was slated by upstream to be a replacement for Amber, and it inherited its player count restrictions. Regardless of the quality of the map, snowball station does not seem appropriate for medium-high populations.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
MAPS:
- tweak: On Snowball: Adjusted player count requirements to be 5 to 30, instead of 15 to 50.


