### PR TITLE
Buff adv jet injector, nerf bluespace syringe, fix comments

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -1,11 +1,11 @@
-<!-- Carpmosia-start - reagentTransfer -->
+<!-- Carpmosia-start - Base 60 Chem -->
 <controls:FancyWindow xmlns="https://spacestation14.io"
                 xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                 xmlns:gfx="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
                 MinSize="670 670"
                 Title="{Loc 'chem-master-bound-user-interface-title'}">
-<!-- Carpmosia-end - reagentTransfer -->
+<!-- Carpmosia-end - Base 60 Chem -->
     <TabContainer Name="Tabs" Margin="5 5 7 5"> 
         <BoxContainer Orientation="Vertical" HorizontalExpand="True" Margin="5" SeparationOverride="10">
             <!-- Input container info -->

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -120,11 +120,11 @@ namespace Content.Client.Chemistry.UI
                 ("20", ChemMasterReagentAmount.U20, StyleClass.ButtonOpenBoth),
                 ("25", ChemMasterReagentAmount.U25, StyleClass.ButtonOpenBoth),
                 ("30", ChemMasterReagentAmount.U30, StyleClass.ButtonOpenBoth),
-                ("40", ChemMasterReagentAmount.U40, StyleClass.ButtonOpenBoth), // Carpmosia-edit - reagentTransfer
+                ("40", ChemMasterReagentAmount.U40, StyleClass.ButtonOpenBoth), // Carpmosia-edit - Base 60 Chem
                 ("50", ChemMasterReagentAmount.U50, StyleClass.ButtonOpenBoth),
-                ("60", ChemMasterReagentAmount.U60, StyleClass.ButtonOpenBoth), // Carpmosia-edit - reagentTransfer
+                ("60", ChemMasterReagentAmount.U60, StyleClass.ButtonOpenBoth), // Carpmosia-edit - Base 60 Chem
                 ("100", ChemMasterReagentAmount.U100, StyleClass.ButtonOpenBoth),
-                ("120", ChemMasterReagentAmount.U120, StyleClass.ButtonOpenBoth), // Carpmosia-edit - reagentTransfer
+                ("120", ChemMasterReagentAmount.U120, StyleClass.ButtonOpenBoth), // Carpmosia-edit - Base 60 Chem
                 (Loc.GetString("chem-master-window-buffer-all-amount"), ChemMasterReagentAmount.All, StyleClass.ButtonOpenLeft),
             };
 

--- a/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
+++ b/Content.Client/Chemistry/UI/ReagentDispenserWindow.xaml
@@ -9,7 +9,7 @@
     <BoxContainer Orientation="Horizontal">
         <BoxContainer Orientation="Vertical" MinWidth="170">
             <Label Text="{Loc 'reagent-dispenser-window-amount-to-dispense-label'}" HorizontalAlignment="Center" />
-            <!-- Carpmosia-start - reagentTransfer -->
+            <!-- Carpmosia-start - Base 60 Chem -->
             <ui:ButtonGrid
                 Name="AmountGrid"
                 Access="Public"
@@ -18,7 +18,7 @@
                 Margin="5"
                 ButtonList="1,5,10,15,20,25,30,40,50,60,100,120"
                 RadioGroup="True">
-            <!-- Carpmosia-end - reagentTransfer -->
+            <!-- Carpmosia-end - Base 60 Chem -->
             </ui:ButtonGrid>
             <Control VerticalExpand="True" />
             <Label Name="ContainerInfoName"

--- a/Content.Shared/Chemistry/SharedChemMaster.cs
+++ b/Content.Shared/Chemistry/SharedChemMaster.cs
@@ -116,11 +116,11 @@ namespace Content.Shared.Chemistry
         U20 = 20,
         U25 = 25,
         U30 = 30,
-        U40 = 40, // Carpmosia-edit - reagentTransfer
+        U40 = 40, // Carpmosia-edit - Base 60 Chem
         U50 = 50,
-        U60 = 60, // Carpmosia-edit - reagentTransfer
+        U60 = 60, // Carpmosia-edit - Base 60 Chem
         U100 = 100,
-        U120 = 120, // Carpmosia-edit - reagentTransfer
+        U120 = 120, // Carpmosia-edit - Base 60 Chem
         All,
     }
 

--- a/Content.Shared/Chemistry/SharedReagentDispenser.cs
+++ b/Content.Shared/Chemistry/SharedReagentDispenser.cs
@@ -52,7 +52,7 @@ namespace Content.Shared.Chemistry
                 case "30":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U30;
                     break;
-                // Carpmosia-start - reagentTransfer
+                // Carpmosia-start - Base 60 Chem
                 case "40":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U40;
                     break;
@@ -68,7 +68,7 @@ namespace Content.Shared.Chemistry
                 case "120":
                     ReagentDispenserDispenseAmount = ReagentDispenserDispenseAmount.U120;
                     break;
-                // Carpmosia-end - reagentTransfer
+                // Carpmosia-end - Base 60 Chem
                 default:
                     throw new Exception($"Cannot convert the string `{s}` into a valid ReagentDispenser DispenseAmount");
             }
@@ -115,11 +115,11 @@ namespace Content.Shared.Chemistry
         U20 = 20,
         U25 = 25,
         U30 = 30,
-        U40 = 40, // Carpmosia-edit - reagentTransfer
+        U40 = 40, // Carpmosia-edit - Base 60 Chem
         U50 = 50,
-        U60 = 60, // Carpmosia-edit - reagentTransfer
+        U60 = 60, // Carpmosia-edit - Base 60 Chem
         U100 = 100,
-        U120 = 120, // Carpmosia-edit - reagentTransfer
+        U120 = 120, // Carpmosia-edit - Base 60 Chem
     }
 
     [Serializable, NetSerializable]

--- a/Resources/Prototypes/Chemistry/injector_modes.yml
+++ b/Resources/Prototypes/Chemistry/injector_modes.yml
@@ -48,8 +48,7 @@
   - 5
   - 10
   - 15
-  - 30 # Carpmosia-start - extendedReagentStorage
-  - 50
+  - 30 # Carpmosia-edit - Base 60 Chem
 
 - type: injectorMode
   parent: [ BaseSyringeMode, BaseInjectMode ]

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -21,7 +21,7 @@
   - type: SolutionContainerManager
     solutions:
       puddle:
-        maxVol: 1200 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 1200 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Vomit
           Quantity: 10
@@ -34,7 +34,7 @@
   - type: SolutionContainerManager
     solutions:
       puddle:
-        maxVol: 1200 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 1200 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Egg
           Quantity: 6 # same as when cooking
@@ -47,7 +47,7 @@
   - type: SolutionContainerManager
     solutions:
       puddle:
-        maxVol: 1200 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 1200 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: JuiceTomato
           Quantity: 10
@@ -60,7 +60,7 @@
   - type: SolutionContainerManager
     solutions:
       puddle:
-        maxVol: 1200 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 1200 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Blood
           Quantity: 5
@@ -73,7 +73,7 @@
   - type: SolutionContainerManager
     solutions:
       puddle:
-        maxVol: 1200 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 1200 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Blood
           Quantity: 30
@@ -86,7 +86,7 @@
   - type: SolutionContainerManager
     solutions:
       puddle:
-        maxVol: 1200 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 1200 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: FluorosulfuricAcid
           Quantity: 5
@@ -99,7 +99,7 @@
   - type: SolutionContainerManager
     solutions:
       puddle:
-        maxVol: 1200 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 1200 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: FluorosulfuricAcid
           Quantity: 15
@@ -112,7 +112,7 @@
   - type: SolutionContainerManager
     solutions:
       puddle:
-        maxVol: 1200 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 1200 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: JuiceWatermelon
           Quantity: 30
@@ -125,7 +125,7 @@
   - type: SolutionContainerManager
     solutions:
       puddle:
-        maxVol: 1200 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 1200 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Flour
           Quantity: 15
@@ -192,7 +192,7 @@
   - type: SolutionContainerManager
     solutions:
       puddle:
-        maxVol: 1200 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 1200 # Carpmosia-edit - Base 60 Chem
   - type: Puddle
   - type: MixableSolution
     solution: puddle

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_flasks.yml
@@ -6,7 +6,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 60 # Carpmosia-edit - reagentStorage
+        maxVol: 60 # Carpmosia-edit - Base 60 Chem
   - type: Sprite
     sprite: Objects/Consumable/Drinks/flask.rsi
   - type: FitsInDispenser
@@ -29,7 +29,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 60 # Carpmosia-edit - reagentStorage
+        maxVol: 60 # Carpmosia-edit - Base 60 Chem
   - type: Sprite
     sprite: Objects/Consumable/Drinks/flask_old.rsi
   - type: FitsInDispenser
@@ -58,7 +58,7 @@
       drink:
         reagents:
         - ReagentId: Water
-          Quantity: 60 # Carpmosia-edit - reagentStorage
+          Quantity: 60 # Carpmosia-edit - Base 60 Chem
   - type: TrashOnSolutionEmpty
     solution: drink
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_fun.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_fun.yml
@@ -68,10 +68,10 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 1200 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 1200 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: SpaceLube
-          Quantity: 1200 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 1200 # Carpmosia-edit - Base 60 Chem
   - type: SolutionRegeneration
     solution: beaker
     generated:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_special.yml
@@ -46,10 +46,10 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 120 # Carpmosia-edit - reagentStorage
+        maxVol: 120 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Tea
-          Quantity: 120 # Carpmosia-edit - reagentStorage
+          Quantity: 120 # Carpmosia-edit - Base 60 Chem
   - type: Sprite
     sprite: Objects/Consumable/Drinks/teapot.rsi
   - type: FitsInDispenser
@@ -116,7 +116,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 120 # Carpmosia-edit - reagentStorage
+        maxVol: 120 # Carpmosia-edit - Base 60 Chem
   - type: FitsInDispenser
     solution: drink
   - type: ExaminableSolution

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/sprays.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/sprays.yml
@@ -14,10 +14,10 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 120 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 120 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: PlantBGone
-          Quantity: 120 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 120 # Carpmosia-edit - Base 60 Chem
   - type: DrainableSolution
     solution: spray
   - type: Item
@@ -37,10 +37,10 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 60 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 60 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: WeedKiller
-          Quantity: 60 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 60 # Carpmosia-edit - Base 60 Chem
   - type: DrainableSolution
     solution: spray
   - type: Spillable
@@ -65,10 +65,10 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 60 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 60 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: PestKiller
-          Quantity: 60 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 60 # Carpmosia-edit - Base 60 Chem
   - type: DrainableSolution
     solution: spray
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -27,7 +27,7 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 120 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 120 # Carpmosia-edit - Base 60 Chem
   - type: RefillableSolution
     solution: spray
   - type: DrainableSolution
@@ -61,7 +61,7 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 300 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 300 # Carpmosia-edit - Base 60 Chem
   - type: Spray
     transferAmount: 15
     sprayedPrototype: BigVapor
@@ -82,10 +82,10 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 120 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 120 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Water
-          Quantity: 120 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 120 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   description: BLAM!-brand non-foaming space cleaner!
@@ -96,10 +96,10 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 120 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 120 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: SpaceCleaner
-          Quantity: 120 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 120 # Carpmosia-edit - Base 60 Chem
   - type: Label
     currentLabel: space cleaner
   - type: Tag
@@ -132,10 +132,10 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 240 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 240 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: SpaceCleaner
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: MegaSprayBottle
@@ -147,10 +147,10 @@
   - type: SolutionContainerManager
     solutions:
       spray:
-        maxVol: 600 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 600 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: SpaceCleaner
-          Quantity: 600 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 600 # Carpmosia-edit - Base 60 Chem
 
 # Vapor
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -160,7 +160,7 @@
   - type: SolutionContainerManager
     solutions:
       hypospray:
-        maxVol: 20
+        maxVol: 30 # Carpmosia-edit - Base 60 Chem
   - type: SolutionContainerVisuals
     maxFillLevels: 4
   - type: Injector

--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -7,7 +7,7 @@
     - type: SolutionContainerManager
       solutions:
         beaker:
-          maxVol: 240 # Carpmosia-edit - extendedReagentStorage
+          maxVol: 240 # Carpmosia-edit - Base 60 Chem
     # Carpmosia-start - Closeable Jugs
     - type: GenericVisualizer
       visuals:
@@ -117,9 +117,9 @@
       beaker:
         reagents:
         - ReagentId: Puncturase
-          Quantity: 192 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 192 # Carpmosia-edit - Base 60 Chem
         - ReagentId: TranexamicAcid
-          Quantity: 48 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 48 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -133,9 +133,9 @@
       beaker:
         reagents:
         - ReagentId: Pyrazine
-          Quantity: 60 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 60 # Carpmosia-edit - Base 60 Chem
         - ReagentId: Dermaline
-          Quantity: 180 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 180 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -149,9 +149,9 @@
       beaker:
         reagents:
         - ReagentId: DexalinPlus
-          Quantity: 120 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 120 # Carpmosia-edit - Base 60 Chem
         - ReagentId: Saline
-          Quantity: 120 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 120 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -165,7 +165,7 @@
       beaker:
         reagents:
         - ReagentId: Tricordrazine
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -179,7 +179,7 @@
       beaker:
         reagents:
         - ReagentId: Blood
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -193,7 +193,7 @@
       beaker:
         reagents:
         - ReagentId: Water
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -208,7 +208,7 @@
       beaker:
         reagents:
         - ReagentId: Carbon
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -223,7 +223,7 @@
       beaker:
         reagents:
         - ReagentId: Iodine
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -238,7 +238,7 @@
       beaker:
         reagents:
         - ReagentId: Fluorine
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -253,7 +253,7 @@
       beaker:
         reagents:
         - ReagentId: Chlorine
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -268,7 +268,7 @@
       beaker:
         reagents:
         - ReagentId: Aluminium
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -283,7 +283,7 @@
       beaker:
         reagents:
         - ReagentId: Phosphorus
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -298,7 +298,7 @@
       beaker:
         reagents:
         - ReagentId: Sulfur
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -313,7 +313,7 @@
       beaker:
         reagents:
         - ReagentId: Silicon
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -328,7 +328,7 @@
       beaker:
         reagents:
         - ReagentId: Hydrogen
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -343,7 +343,7 @@
       beaker:
         reagents:
         - ReagentId: Lithium
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -358,7 +358,7 @@
       beaker:
         reagents:
         - ReagentId: Sodium
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -373,7 +373,7 @@
       beaker:
         reagents:
         - ReagentId: Potassium
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -388,7 +388,7 @@
       beaker:
         reagents:
         - ReagentId: Radium
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -403,7 +403,7 @@
       beaker:
         reagents:
         - ReagentId: Iron
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -418,7 +418,7 @@
       beaker:
         reagents:
         - ReagentId: Copper
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -433,7 +433,7 @@
       beaker:
         reagents:
         - ReagentId: Gold
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -448,7 +448,7 @@
       beaker:
         reagents:
         - ReagentId: Mercury
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -463,7 +463,7 @@
       beaker:
         reagents:
         - ReagentId: Silver
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -478,7 +478,7 @@
       beaker:
         reagents:
         - ReagentId: Ethanol
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -493,7 +493,7 @@
       beaker:
         reagents:
         - ReagentId: Sugar
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -508,7 +508,7 @@
       beaker:
         reagents:
         - ReagentId: Nitrogen
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -523,7 +523,7 @@
       beaker:
         reagents:
         - ReagentId: Oxygen
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -538,7 +538,7 @@
       beaker:
         reagents:
         - ReagentId: PlantBGone
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Jug
@@ -553,4 +553,4 @@
       beaker:
         reagents:
         - ReagentId: WeldingFuel
-          Quantity: 240 # Carpmosia-edit - extendedReagentStorage
+          Quantity: 240 # Carpmosia-edit - Base 60 Chem

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -24,7 +24,7 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 60 # Carpmosia-edit - reagentStorage
+        maxVol: 60 # Carpmosia-edit - Base 60 Chem
   - type: MixableSolution
     solution: beaker
   - type: FitsInDispenser
@@ -124,7 +124,7 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 60 # Carpmosia-edit - reagentStorage
+        maxVol: 60 # Carpmosia-edit - Base 60 Chem
   - type: MixableSolution
     solution: beaker
   - type: FitsInDispenser
@@ -193,10 +193,10 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 60 # Carpmosia-edit - reagentStorage
+        maxVol: 60 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Cryoxadone
-          Quantity: 60 # Carpmosia-edit - reagentStorage
+          Quantity: 60 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Beaker
@@ -208,10 +208,10 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 60 # Carpmosia-edit - reagentStorage
+        maxVol: 60 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Arithrazine
-          Quantity: 60 # Carpmosia-edit - reagentStorage
+          Quantity: 60 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Beaker
@@ -223,10 +223,10 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 60 # Carpmosia-edit - reagentStorage
+        maxVol: 60 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Sigynate
-          Quantity: 60 # Carpmosia-edit - reagentStorage
+          Quantity: 60 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Beaker
@@ -238,10 +238,10 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 60 # Carpmosia-edit - reagentStorage
+        maxVol: 60 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Phalanximine
-          Quantity: 60 # Carpmosia-edit - reagentStorage
+          Quantity: 60 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Beaker
@@ -253,10 +253,10 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 60 # Carpmosia-edit - reagentStorage
+        maxVol: 60 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Diphenhydramine
-          Quantity: 60 # Carpmosia-edit - reagentStorage
+          Quantity: 60 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Beaker
@@ -268,10 +268,10 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 60 # Carpmosia-edit - reagentStorage
+        maxVol: 60 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Bruizine
-          Quantity: 60 # Carpmosia-edit - reagentStorage
+          Quantity: 60 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   parent: Beaker
@@ -283,10 +283,10 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 60 # Carpmosia-edit - reagentStorage
+        maxVol: 60 # Carpmosia-edit - Base 60 Chem
         reagents:
         - ReagentId: Lacerinol
-          Quantity: 60 # Carpmosia-edit - reagentStorage
+          Quantity: 60 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   name: large beaker
@@ -309,7 +309,7 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 120 # Carpmosia-edit - reagentStorage
+        maxVol: 120 # Carpmosia-edit - Base 60 Chem
   - type: Appearance
   - type: SolutionContainerVisuals
     maxFillLevels: 6
@@ -359,7 +359,7 @@
   - type: SolutionContainerManager
     solutions:
       beaker:
-        maxVol: 1200 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 1200 # Carpmosia-edit - Base 60 Chem
 
 - type: entity
   name: dropper
@@ -578,7 +578,7 @@
   - type: SolutionContainerManager
     solutions:
       injector:
-        maxVol: 120 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 120 # Carpmosia-edit - Base 60 Chem
   - type: Injector
     activeModeProtoId: BluespaceSyringeDrawMode
     allowedModes:

--- a/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/bucket.yml
@@ -18,7 +18,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 300 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 300 # Carpmosia-edit - Base 60 Chem
   - type: SolutionTransfer
     transferAmount: 100
     maxTransferAmount: 100
@@ -44,4 +44,4 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 600 # Carpmosia-edit - extendedReagentStorage
+        maxVol: 600 # Carpmosia-edit - Base 60 Chem


### PR DESCRIPTION
## About the PR
Removed 50u transfer option from bluespace syringes.
Increased advanced jet injector to 30u storage.
Changed comments of `reagentStorage`, `reagentTransfer`, and `extendedReagentStorage`, from #14, #16, and #48 respectively, to `Base 60 Chem`.

## Why / Balance
50u transfer option removed as bluespace syringes at a tier two research here.
Increased advanced jet injector to match with bluespace syringe, which is the same tier.
Comments changed to be more in line with current comment standards.

## Technical details
Minor yaml work and comment changes.

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- remove: Removed 50u transfer mode from bluespace syringes that was added by upstream.
- tweak: Increased capacity of advanced jet injectors to 30u.
