### PR TITLE
Improve AI navmap perf

### DIFF
--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -32,9 +32,17 @@ public sealed class StationAiOverlay : Overlay
     private readonly NavMapControl _navMap = new(); // Carpmosia-edit - AI Navmap
 
     private readonly OverlayResourceCache<CachedResources> _resources = new();
-    private Dictionary<Color, Color> _sRGBLookUp = new(); // Carpmosia-edit - AI Navmap
 
-    private float _updateRate = 1f / 30f;
+    // Carpmosia-start - AI Navmap
+    private readonly Dictionary<Color, Color> _sRgbLookUp = new();
+    private static readonly RenderTargetFormatParameters RenderTargetFormatParameters = new(RenderTargetColorFormat.Rgba8Srgb);
+
+    private static readonly List<Vector2> TileLinesToDraw = [];
+    private static readonly List<Vector2> TileRectsToDraw = [];
+
+    private const float UpdateRate = 1f / 30f;
+    // Carpmosia-end - AI Navmap
+
     private float _accumulator;
 
     public StationAiOverlay()
@@ -54,10 +62,13 @@ public sealed class StationAiOverlay : Overlay
         {
             res.StaticTexture?.Dispose();
             res.StencilTexture?.Dispose();
-            res.StencilTexture = _clyde.CreateRenderTarget(args.Viewport.Size, new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb), name: "station-ai-stencil");
+
+            // Carpmosia-start - AI Navmap
+            res.StencilTexture = _clyde.CreateRenderTarget(args.Viewport.Size, RenderTargetFormatParameters, name: "station-ai-stencil");
             res.StaticTexture = _clyde.CreateRenderTarget(args.Viewport.Size,
-                new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb),
+                RenderTargetFormatParameters,
                 name: "station-ai-static");
+            // Carpmosia-end - AI Navmap
         }
 
         var worldHandle = args.WorldHandle;
@@ -81,7 +92,9 @@ public sealed class StationAiOverlay : Overlay
             _navMap.AiFrameUpdate((float) _timing.FrameTime.TotalSeconds, gridUid); // Carpmosia-edit - AI Navmap
             if (_accumulator <= 0f)
             {
-                _accumulator = MathF.Max(0f, _accumulator + _updateRate);
+                // Carpmosia-start - AI Navmap
+                _accumulator = MathF.Max(0f, _accumulator + UpdateRate);
+                // Carpmosia-end - AI Navmap
                 _visibleTiles.Clear();
                 _entManager.System<StationAiVisionSystem>().GetView((gridUid, broadphase, grid), worldBounds, _visibleTiles);
             }
@@ -167,64 +180,66 @@ public sealed class StationAiOverlay : Overlay
     // Carpmosia-start - AI Navmap
     protected void DrawNavMap(DrawingHandleWorld handle, MapGridComponent grid)
     {
-        if (!_sRGBLookUp.TryGetValue(_navMap.WallColor, out var wallsRGB))
+        if (!_sRgbLookUp.TryGetValue(_navMap.WallColor, out var wallsRgb))
         {
-            wallsRGB = Color.ToSrgb(_navMap.WallColor);
-            _sRGBLookUp[_navMap.WallColor] = wallsRGB;
+            wallsRgb = Color.ToSrgb(_navMap.WallColor);
+            _sRgbLookUp[_navMap.WallColor] = wallsRgb;
         }
 
         // Draw floor tiles
-        if (_navMap.TilePolygons.Any())
+        if (_navMap.TilePolygons.Count != 0)
         {
             foreach (var (polygonVerts, polygonColor) in _navMap.TilePolygons)
             {
-                handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, polygonVerts[..polygonVerts.Length], polygonColor);
+                handle.DrawPrimitives(DrawPrimitiveTopology.TriangleFan, polygonVerts.AsSpan()[..], polygonColor);
             }
         }
 
         // Draw map lines
-        if (_navMap.TileLines.Any())
+        if (_navMap.TileLines.Count != 0)
         {
-            var lines = new ValueList<Vector2>(_navMap.TileLines.Count * 2);
+            TileLinesToDraw.Clear();
+            TileLinesToDraw.EnsureCapacity(_navMap.TileLines.Count * 2);
 
             foreach (var (o, t) in _navMap.TileLines)
             {
-                var origin = new Vector2(o.X, -o.Y);
-                var terminus = new Vector2(t.X, -t.Y);
+                var origin = o with { Y = -o.Y };
+                var terminus = t with { Y = -t.Y };
 
-                lines.Add(origin);
-                lines.Add(terminus);
+                TileLinesToDraw.Add(origin);
+                TileLinesToDraw.Add(terminus);
             }
 
-            if (lines.Count > 0)
-                handle.DrawPrimitives(DrawPrimitiveTopology.LineList, lines.Span, wallsRGB);
+            if (TileLinesToDraw.Count > 0)
+                handle.DrawPrimitives(DrawPrimitiveTopology.LineList, TileLinesToDraw, wallsRgb);
         }
 
         // Draw map rects
-        if (_navMap.TileRects.Any())
+        if (_navMap.TileRects.Count != 0)
         {
-            var rects = new ValueList<Vector2>(_navMap.TileRects.Count * 8);
+            TileRectsToDraw.Clear();
+            TileRectsToDraw.EnsureCapacity(_navMap.TileRects.Count * 8);
 
             foreach (var (lt, rb) in _navMap.TileRects)
             {
-                var leftTop = new Vector2(lt.X, -lt.Y);
-                var rightBottom = new Vector2(rb.X, -rb.Y);
+                var leftTop = lt with { Y = -lt.Y };
+                var rightBottom = rb with { Y = -rb.Y };
 
                 var rightTop = new Vector2(rightBottom.X, leftTop.Y);
                 var leftBottom = new Vector2(leftTop.X, rightBottom.Y);
 
-                rects.Add(leftTop);
-                rects.Add(rightTop);
-                rects.Add(rightTop);
-                rects.Add(rightBottom);
-                rects.Add(rightBottom);
-                rects.Add(leftBottom);
-                rects.Add(leftBottom);
-                rects.Add(leftTop);
+                TileRectsToDraw.Add(leftTop);
+                TileRectsToDraw.Add(rightTop);
+                TileRectsToDraw.Add(rightTop);
+                TileRectsToDraw.Add(rightBottom);
+                TileRectsToDraw.Add(rightBottom);
+                TileRectsToDraw.Add(leftBottom);
+                TileRectsToDraw.Add(leftBottom);
+                TileRectsToDraw.Add(leftTop);
             }
 
-            if (rects.Count > 0)
-                handle.DrawPrimitives(DrawPrimitiveTopology.LineList, rects.Span, wallsRGB);
+            if (TileRectsToDraw.Count > 0)
+                handle.DrawPrimitives(DrawPrimitiveTopology.LineList, TileRectsToDraw, wallsRgb);
         }
     }
     // Carpmosia-end - AI Navmap

--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -92,9 +92,7 @@ public sealed class StationAiOverlay : Overlay
             _navMap.AiFrameUpdate((float) _timing.FrameTime.TotalSeconds, gridUid); // Carpmosia-edit - AI Navmap
             if (_accumulator <= 0f)
             {
-                // Carpmosia-start - AI Navmap
-                _accumulator = MathF.Max(0f, _accumulator + UpdateRate);
-                // Carpmosia-end - AI Navmap
+                _accumulator = MathF.Max(0f, _accumulator + UpdateRate); // Carpmosia-edit - AI Navmap
                 _visibleTiles.Clear();
                 _entManager.System<StationAiVisionSystem>().GetView((gridUid, broadphase, grid), worldBounds, _visibleTiles);
             }


### PR DESCRIPTION
## About the PR
Improves navmap perf.

Idle alloc rate from 500+ KiB/frame to ~40 KiB/frame, also improves moving drawing perf slightly but there are still some issues that are hard to resolve due to the nature of the implementation.

## Why / Balance
This is something I did in https://github.com/space-wizards/space-station-14/pull/41889/changes/ca016ab6962bc4a849d2f5bdb3b0d4f258dcc6e9 as like a baseline poke into cleaning up the PR. In general I don't think this is right right approach as in order to make this usable for AI in the future you would basically have to create your own bespoke AI-navmap implementation that properly offsets things. I'd have to think about it more.  But that is your choice to make.

Just bringing this down here because nobody seems to have picked it up and it's free.

Code is MIT.

## Technical details
Creating a ValueList every single draw call is not performant, the backing implementation is still an array. Just re-use the array, you don't need to create one every time you draw.

## Media
<img width="729" height="719" alt="image" src="https://github.com/user-attachments/assets/7d085921-c753-4448-a5ee-67aca3d61bb4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
:cl:
- fix: Improved performance for the AI navmap when idle on lower end machines.
