### PR TITLE
Make brute damage appear blue on avali

### DIFF
--- a/Resources/Prototypes/_Carpmosia/Body/Species/avali.yml
+++ b/Resources/Prototypes/_Carpmosia/Body/Species/avali.yml
@@ -201,6 +201,13 @@
       reagents:
       - ReagentId: AmmoniaBlood
         Quantity: 300
+  - type: DamageVisuals
+    damageOverlayGroups:
+      Brute:
+        sprite: Mobs/Effects/brute_damage.rsi
+        color: "#7a8bf2"
+      Burn:
+        sprite: Mobs/Effects/burn_damage.rsi
   - type: ThermalRegulator
     metabolismHeat: 400 # icebirb go brrr
     radiatedHeat: 100


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
This PR changes avali brute damage visuals to be blue instead of red, to reflect their ammonia blood.

## Why / Balance
Avali brute damage visuals were previously red, which does not align with the color of their blood.

## Technical details
Copied over the Vox (who too have ammonia blood) `DamageVisuals` component over to the avali body prototype.

## Media
<img width="343" height="333" alt="avali with blue blood on sprite" src="https://github.com/user-attachments/assets/1ef9b65c-9164-4f0e-920f-7d932d3a6dcc" />

## Breaking changes
Should not affect other species or gameplay elements.

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- fix: Brute damage inflicted on avali now visually appears as blue instead of red.
