### PR TITLE
Make dead/crit bodies much harder to pull

### DIFF
--- a/Content.Shared/Standing/StandingStateComponent.cs
+++ b/Content.Shared/Standing/StandingStateComponent.cs
@@ -14,11 +14,20 @@ namespace Content.Shared.Standing
         [DataField, AutoNetworkedField]
         public bool Standing { get; set; } = true;
 
+        [DataField, AutoNetworkedField]
+        public bool Incapacitated { get; set; } = false;
+
         /// <summary>
         /// Friction modifier applied to an entity in the downed state.
         /// </summary>
         [DataField, AutoNetworkedField]
         public float DownFrictionMod = 0.4f;
+
+        /// <summary>
+        /// Friction modifier applied to an entity in an incapacitated (crit/dead) state.
+        /// </summary>
+        [DataField, AutoNetworkedField]
+        public float LimpFrictionMod = 3f;
 
         /// <summary>
         ///     List of fixtures that had their collision mask changed when the entity was downed.

--- a/Content.Shared/Standing/StandingStateComponent.cs
+++ b/Content.Shared/Standing/StandingStateComponent.cs
@@ -14,8 +14,10 @@ namespace Content.Shared.Standing
         [DataField, AutoNetworkedField]
         public bool Standing { get; set; } = true;
 
+        // Carpmosia-start - make dead/crit bodies much harder to pull
         [DataField, AutoNetworkedField]
         public bool Incapacitated { get; set; } = false;
+        // Carpmosia-end - make dead/crit bodies much harder to pull
 
         /// <summary>
         /// Friction modifier applied to an entity in the downed state.
@@ -23,11 +25,13 @@ namespace Content.Shared.Standing
         [DataField, AutoNetworkedField]
         public float DownFrictionMod = 0.4f;
 
+        // Carpmosia-start - make dead/crit bodies much harder to pull
         /// <summary>
         /// Friction modifier applied to an entity in an incapacitated (crit/dead) state.
         /// </summary>
         [DataField, AutoNetworkedField]
         public float LimpFrictionMod = 3f;
+        // Carpmosia-end - make dead/crit bodies much harder to pull
 
         /// <summary>
         ///     List of fixtures that had their collision mask changed when the entity was downed.

--- a/Content.Shared/Standing/StandingStateComponent.cs
+++ b/Content.Shared/Standing/StandingStateComponent.cs
@@ -14,11 +14,6 @@ namespace Content.Shared.Standing
         [DataField, AutoNetworkedField]
         public bool Standing { get; set; } = true;
 
-        // Carpmosia-start - make dead/crit bodies much harder to pull
-        [DataField, AutoNetworkedField]
-        public bool Incapacitated { get; set; } = false;
-        // Carpmosia-end - make dead/crit bodies much harder to pull
-
         /// <summary>
         /// Friction modifier applied to an entity in the downed state.
         /// </summary>
@@ -26,6 +21,9 @@ namespace Content.Shared.Standing
         public float DownFrictionMod = 0.4f;
 
         // Carpmosia-start - make dead/crit bodies much harder to pull
+        [DataField, AutoNetworkedField]
+        public bool Incapacitated { get; set; } = false;
+
         /// <summary>
         /// Friction modifier applied to an entity in an incapacitated (crit/dead) state.
         /// </summary>

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -5,8 +5,8 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Physics;
 using Content.Shared.Rotation;
-using Content.Shared.Mobs;
-using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs; // Carpmosia-edit - make dead/crit bodies much harder to pull
+using Content.Shared.Mobs.Components; // Carpmosia-edit - make dead/crit bodies much harder to pull
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
@@ -30,7 +30,7 @@ public sealed class StandingStateSystem : EntitySystem
         SubscribeLocalEvent<StandingStateComponent, RefreshFrictionModifiersEvent>(OnRefreshFrictionModifiers);
         SubscribeLocalEvent<StandingStateComponent, TileFrictionEvent>(OnTileFriction);
         SubscribeLocalEvent<StandingStateComponent, EndClimbEvent>(OnEndClimb);
-        SubscribeLocalEvent<StandingStateComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<StandingStateComponent, MobStateChangedEvent>(OnMobStateChanged); // Carpmosia-edit - make dead/crit bodies much harder to pull
     }
 
     private void OnMobTargetCollide(Entity<StandingStateComponent> ent, ref AttemptMobTargetCollideEvent args)
@@ -54,11 +54,13 @@ public sealed class StandingStateSystem : EntitySystem
         if (entity.Comp.Standing)
             return;
 
+        // Carpmosia-start - make dead/crit bodies much harder to pull
         if (entity.Comp.Incapacitated) {
             args.ModifyFriction(entity.Comp.LimpFrictionMod);
             args.ModifyAcceleration(entity.Comp.LimpFrictionMod);
             return;
         }
+        // Carpmosia-end - make dead/crit bodies much harder to pull
 
         args.ModifyFriction(entity.Comp.DownFrictionMod);
         args.ModifyAcceleration(entity.Comp.DownFrictionMod);
@@ -66,6 +68,7 @@ public sealed class StandingStateSystem : EntitySystem
 
     private void OnTileFriction(Entity<StandingStateComponent> entity, ref TileFrictionEvent args)
     {
+        // Carpmosia-start - make dead/crit bodies much harder to pull
         if (entity.Comp.Standing)
             return;
 
@@ -73,6 +76,7 @@ public sealed class StandingStateSystem : EntitySystem
             args.Modifier *= entity.Comp.LimpFrictionMod;
             return;
         }
+        // Carpmosia-end - make dead/crit bodies much harder to pull
 
         args.Modifier *= entity.Comp.DownFrictionMod;
     }
@@ -86,10 +90,12 @@ public sealed class StandingStateSystem : EntitySystem
         ChangeLayers(entity);
     }
 
+    // Carpmosia-start - make dead/crit bodies much harder to pull
     private void OnMobStateChanged(Entity<StandingStateComponent> entity, ref MobStateChangedEvent args)
     {
         entity.Comp.Incapacitated = (args.NewMobState == MobState.Critical || args.NewMobState == MobState.Dead);
     }
+    // Carpmosia-end - make dead/crit bodies much harder to pull
 
     public bool IsMatchingState(Entity<StandingStateComponent?> entity, bool standing)
     {

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -76,9 +76,9 @@ public sealed class StandingStateSystem : EntitySystem
             args.Modifier *= entity.Comp.LimpFrictionMod;
             return;
         }
-        // Carpmosia-end - make dead/crit bodies much harder to pull
 
         args.Modifier *= entity.Comp.DownFrictionMod;
+        // Carpmosia-end - make dead/crit bodies much harder to pull
     }
 
     private void OnEndClimb(Entity<StandingStateComponent> entity, ref EndClimbEvent args)

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -88,12 +88,7 @@ public sealed class StandingStateSystem : EntitySystem
 
     private void OnMobStateChanged(Entity<StandingStateComponent> entity, ref MobStateChangedEvent args)
     {
-        if (args.NewMobState == MobState.Critical || args.NewMobState == MobState.Dead) {
-            entity.Comp.Incapacitated = true;
-            return;
-        }
-
-        entity.Comp.Incapacitated = false;
+        entity.Comp.Incapacitated = (args.NewMobState == MobState.Critical || args.NewMobState == MobState.Dead);
     }
 
     public bool IsMatchingState(Entity<StandingStateComponent?> entity, bool standing)

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -5,6 +5,8 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Physics;
 using Content.Shared.Rotation;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
@@ -28,6 +30,7 @@ public sealed class StandingStateSystem : EntitySystem
         SubscribeLocalEvent<StandingStateComponent, RefreshFrictionModifiersEvent>(OnRefreshFrictionModifiers);
         SubscribeLocalEvent<StandingStateComponent, TileFrictionEvent>(OnTileFriction);
         SubscribeLocalEvent<StandingStateComponent, EndClimbEvent>(OnEndClimb);
+        SubscribeLocalEvent<StandingStateComponent, MobStateChangedEvent>(OnMobStateChanged);
     }
 
     private void OnMobTargetCollide(Entity<StandingStateComponent> ent, ref AttemptMobTargetCollideEvent args)
@@ -51,14 +54,27 @@ public sealed class StandingStateSystem : EntitySystem
         if (entity.Comp.Standing)
             return;
 
+        if (entity.Comp.Incapacitated) {
+            args.ModifyFriction(entity.Comp.LimpFrictionMod);
+            args.ModifyAcceleration(entity.Comp.LimpFrictionMod);
+            return;
+        }
+
         args.ModifyFriction(entity.Comp.DownFrictionMod);
         args.ModifyAcceleration(entity.Comp.DownFrictionMod);
     }
 
     private void OnTileFriction(Entity<StandingStateComponent> entity, ref TileFrictionEvent args)
     {
-        if (!entity.Comp.Standing)
-            args.Modifier *= entity.Comp.DownFrictionMod;
+        if (entity.Comp.Standing)
+            return;
+
+        if (entity.Comp.Incapacitated) {
+            args.Modifier *= entity.Comp.LimpFrictionMod;
+            return;
+        }
+
+        args.Modifier *= entity.Comp.DownFrictionMod;
     }
 
     private void OnEndClimb(Entity<StandingStateComponent> entity, ref EndClimbEvent args)
@@ -68,6 +84,16 @@ public sealed class StandingStateSystem : EntitySystem
 
         // Currently only Climbing also edits fixtures layers like this so this is fine for now.
         ChangeLayers(entity);
+    }
+
+    private void OnMobStateChanged(Entity<StandingStateComponent> entity, ref MobStateChangedEvent args)
+    {
+        if (args.NewMobState == MobState.Critical || args.NewMobState == MobState.Dead) {
+            entity.Comp.Incapacitated = true;
+            return;
+        }
+
+        entity.Comp.Incapacitated = false;
     }
 
     public bool IsMatchingState(Entity<StandingStateComponent?> entity, bool standing)


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
Applies a higher friction modifier to prone bodies that are incapacitated (crit/dead), making them much harder to move.

## Why / Balance
Gives more of a job to our poor paramedics, who will now have a greater incentive to stabilize (or even treat for the especially proactive) and transport patients in the field. Also encourages more strategic methods of dealing with casualties, ad hoc or otherwise; an example I gave on discord was a bystander using a chair to move a body.

Should lead to overall more interesting RP vs dying -> being dragged to med in like 30 seconds -> being revived -> repeat

## Technical details
This is my first time touching C# code so this might be far from best practice or conventions :godo:
- Adds the `Incapacitated` and `LimpFrictionMod` datafields to `StandingStateComponent`.
- Adds the actual logic to `StandingStateSystem` to apply the correct friction modifier, based on `Incapacitated` which is set according to a `MobStateChangedEvent`.
    - I would prefer to handle this in something like `MobStateSystem` but StandingState overrides any friction modifiers when prone so this just adds another path for that override to take.
## Media
https://github.com/user-attachments/assets/d51d9900-a44f-4ce8-8b63-7a609eb0577b

## Breaking changes
Only public changes are the new datafields in `StandingStateComponent`.

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl: microfiche
- add: Moving incapacitated bodies is now much more cumbersome.