### PR TITLE
Nerf the pocket disabler

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -522,13 +522,13 @@
   - type: StaticPrice
     price: 100
   - type: Gun
-    fireRate: 2
+    fireRate: 3 # Carpmosia-edit - disabler nerf
     projectileSpeed: 35 # any higher and this causes issues in lag
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: BatteryAmmoProvider
     proto: BulletDisablerPractice
-    fireCost: 62.5
+    fireCost: 100 # Carpmosia-edit - disabler nerf
   - type: Tag
     tags:
     - Taser
@@ -556,8 +556,8 @@
       - suitStorage
       - Belt
   - type: BatteryAmmoProvider
-    proto: BulletDisabler
-    fireCost: 62.5
+    proto: BulletDisablerSmg # Carpmosia-edit - disabler nerf
+    fireCost: 100 # Carpmosia-edit - disabler nerf
   - type: GuideHelp
     guides:
     - Security


### PR DESCRIPTION
## General information
Lowers the damage & capacity on the disabler, while increasing it's firerate. Attempts to bring the disabler more in line with the Mk 58 in terms of utility & rapidity against unarmored targets.

|    | Current Disabler | New Disabler | Mk 58 |
| - | ----------------- | ------------- | ------- |
| capacity | 16 shots | 10 shots | 10 + 1 shots |
| damage per hit | 33 stamina | 15 stamina | 16 piercing |
| shots to critical | 4 | 7 | 7 |
| rounds per second | 2 | 3 | 5 |

This transforms the disabler from an Infinite Range Stun Baton into a stamina damage utility. Assuming 100% accuracy (which isn't hard to imagine) the current disabler allows for 6 takedowns on a full charge on it's own. The new disabler can perform only 1 takedown on a magdump - while lending itself to combos with the baton, using slowdown from a disabler helps with finishing the job with a baton, helping with longevity.
This increases the firing cost rather than editing the battery capacity, meaning a full recharge takes the same amount of time.

## Why / Balance
The disabler is comically overtuned. It has theoretically infinite range _and functionally perfect precision_. Assuming all shots land it has nearly identical time to critical as a stun baton. The current disabler _attempts_ to be worse than a baton, but fails the job spectacularly, one (1) more hit than a baton does not make for enough of a difference.

These changes indirectly make the disabler SMG more desirable, turning it from a _direct downgrade_ in practicality, to a _direct upgrade_ in longevity. I opted not to fuck with the energy magnum in this PR because you can't edit one of it's modes while ignoring the others and I have sweeping changes to it in mind for another PR

## Technical details
The laziest possible YAML 4 liner I could muster to achieve the desired effect. Adjusts the fire cost & rate on the disabler, and uses the disabler SMG bolt instead of the basic disabler bolt. Editing the basic disabler bolt would have consequences on the energy magnum I consider out of scope.

## Media

https://github.com/user-attachments/assets/bbf93c87-b696-480a-aaab-0ed65faa973b



## Breaking changes
N/A

## Changelog
:cl:
- tweak: EXPERIMENTAL: The disabler has been brought in line with the Mk 58, a full charge can make one takedown, down from six, in exchange for a higher fire rate.