### PR TITLE
Revert skeletons to free-agents

### DIFF
--- a/Resources/Locale/en-US/_Carpmosia/ghost/role/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/ghost/role/ghost-role-component.ftl
@@ -1,5 +1,3 @@
-ghost-role-information-closet-skeleton-description-nonantagonist = You are arguably one of the oldest members of the station! Get your old job back, choose another one, or simply wander around the station! Remember, you're still a crewmember.
-
 ghost-role-information-giant-spider-name-carpmosia = Giant Spider
 ghost-role-information-giant-spider-description-carpmosia = This station's inhabitants look mighty tasty and cool, and your sticky web is perfect to catch them or make a home with them!
 ghost-role-information-giant-spider-rules-carpmosia = You are a [color={role-type-free-agent-color}][bold]{role-type-free-agent-name}[/bold][/color] with all other giant spiders.

--- a/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/skeleton.yml
@@ -42,15 +42,13 @@
   components:
   - type: GhostRole
     name: ghost-role-information-closet-skeleton-name
-    # Carpmosia-start - Closet Skeletons are not antags.
-    description: ghost-role-information-closet-skeleton-description-nonantagonist
-    rules: ghost-role-information-nonantagonist-rules
-    # Carpmosia-end - Closet Skeletons are not antags.
+    description: ghost-role-information-closet-skeleton-description
+    rules: ghost-role-information-freeagent-rules
     mindRoles:
-    - MindRoleGhostRoleNeutral # Carpmosia-edit - Closet Skeletons are not antags.
+    - MindRoleGhostRoleFreeAgent
     raffle:
       settings: default
   - type: GhostTakeoverAvailable
   - type: Loadout
-    prototypes: [SkeletonPassengerGear] # Carpmosia-edit - Closet Skeletons are not antags.
+    prototypes: [LimitedPassengerGear]
   - type: RandomHumanoidAppearance

--- a/Resources/Prototypes/_Carpmosia/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/_Carpmosia/Roles/Jobs/Fun/misc_startinggear.yml
@@ -1,16 +1,4 @@
 - type: startingGear
-  id: SkeletonPassengerGear
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitColorGrey
-    shoes: ClothingShoesColorBlack
-    id: PassengerPDA
-    ears: ClothingHeadsetGrey
-    back: ClothingBackpack
-  storage:
-    back:
-    - BoxSurvival
-
-- type: startingGear
   id: MobAghostGearCarp
   equipment:
     back: ClothingBackpackSatchelAdmin


### PR DESCRIPTION
## General information
Reverts #39, doesn't keep the added headset, PDA, and backpack, deemed unnecessary.

## Why / Balance
The original change was made in the fork's infancy, as a port from it's progenitor, in response to valid at the time(!!) concerns of low-roleplay skeletons overpowering the station unfairly.
The server has outgrown this change, closet skeletons no longer pose the same problems for fact they exist under entirely different conditions. Carpmosia has recently advanced to an MRP label, cutting the likelyhood of NitRP combat skeletons, and has had a flourishing Security playerbase, consistently Security is the highest staffed department on the station, more than capable of handling the threat one (1) skeleton may pose, __if__ it chooses to antagonize the station.
A glaring issue on Carpmosia is the lack of antagonism actual antagonists perform, this is an easy step one to introducing more threats back into the roundflow on the fork. It is only fair after after the numerous buffs Security has been given on this fork in the past :godo:

## Technical details
Manually reverts changes from linked PR.

## Media
N/A

## Breaking changes
Removed the SkeletonPassengerGear starting gear prototype, and one localization line.

## Changelog
:cl:
- add: Skeletons are now considered free agents again!
- remove: Skeletons spawn without a PDA, backpack, and headset again.