### PR TITLE
Remove current blood bound mindshield deconversion

### DIFF
--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -12,7 +12,6 @@ namespace Content.Shared.Revolutionary;
 
 public abstract class SharedRevolutionarySystem : EntitySystem
 {
-    [Dependency] private readonly SharedBloodBoundSystem _bloodBoundSystem = default!; // Carpmosia-edit - Harmony Blood Bound
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedStunSystem _sharedStun = default!;
 
@@ -47,8 +46,6 @@ public abstract class SharedRevolutionarySystem : EntitySystem
             _sharedStun.TryUpdateParalyzeDuration(uid, stunTime);
             _popupSystem.PopupEntity(Loc.GetString("rev-break-control", ("name", name)), uid);
         }
-
-        _bloodBoundSystem.OnBloodBoundMindshielded((uid, comp), ref init); // Carpmosia-edit - Harmony Blood Bound
     }
 
     /// <summary>

--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -1,4 +1,3 @@
-using Content.Shared.BloodBound.EntitySystems; // Carpmosia-edit - Harmony Blood Bound
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mindshield.Components;
 using Content.Shared.Popups;

--- a/Content.Shared/_Carpmosia/BloodBound/EntitySystems/SharedBloodBoundSystem.cs
+++ b/Content.Shared/_Carpmosia/BloodBound/EntitySystems/SharedBloodBoundSystem.cs
@@ -13,8 +13,6 @@ namespace Content.Shared.BloodBound.EntitySystems;
 public abstract class SharedBloodBoundSystem : EntitySystem
 {
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
-    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
-    [Dependency] private readonly SharedStunSystem _stunSystem = default!;
 
     public override void Initialize()
     {
@@ -43,24 +41,6 @@ public abstract class SharedBloodBoundSystem : EntitySystem
         ref ComponentGetStateAttemptEvent args)
     {
         args.Cancelled = !CanGetState(args.Player);
-    }
-
-    public void OnBloodBoundMindshielded(Entity<MindShieldComponent> entity, ref MapInitEvent args)
-    {
-        if (HasComp<InitialBloodBoundComponent>(entity))
-            return;
-
-        if (!TryComp<BloodBoundComponent>(entity, out var bloodBound))
-            return;
-
-        var name = Identity.Entity(entity, EntityManager);
-        RemCompDeferred<BloodBoundComponent>(entity);
-        if (bloodBound.DeconversionStunTime != null)
-            _stunSystem.TryUpdateParalyzeDuration(entity, bloodBound.DeconversionStunTime);
-        _popupSystem.PopupEntity(
-            Loc.GetString("blood-bound-break-control", ("name", name)),
-            entity,
-            PopupType.MediumCaution);
     }
 
     private bool CanGetState(ICommonSession? player)

--- a/Content.Shared/_Carpmosia/BloodBound/EntitySystems/SharedBloodBoundSystem.cs
+++ b/Content.Shared/_Carpmosia/BloodBound/EntitySystems/SharedBloodBoundSystem.cs
@@ -1,10 +1,6 @@
 using Content.Shared.Actions;
 using Content.Shared.Antag;
 using Content.Shared.BloodBound.Components;
-using Content.Shared.IdentityManagement;
-using Content.Shared.Mindshield.Components;
-using Content.Shared.Popups;
-using Content.Shared.Stunnable;
 using Robust.Shared.GameStates;
 using Robust.Shared.Player;
 

--- a/Resources/Locale/en-US/_Carpmosia/game-ticking/game-presets/preset-bloodbound.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/game-ticking/game-presets/preset-bloodbound.ftl
@@ -16,8 +16,6 @@ blood-bound-role-greeting =
 
 blood-bound-briefing = Collaborate with your blood bound to accomplish all your objectives.
 
-blood-bound-break-control = {CAPITALIZE(THE($name))} has remembered their true allegiance!
-
 # Conversion
 
 blood-bound-convert-failed-no-mind = {CAPITALIZE(THE($converted))} does not have a mind.


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Blood bound converts are no longer deconverted on mindshield.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Currently blood bound are one of the most vulnerable antagonists. Their entire gimmick relies on trading all the equipment and abilities of other antagonists for one guaranteed ally that can be taken away through the application of an implant that security has no reason to withhold under most circumstances. Mental shielding is something that security *has* to be able to apply to people for any reason due to the existence of revolutionaries, and rather than trying to carve out some sort of exception in metagaming rules for blood bound that adds a ton more work for admins, I'd rather address the problem in this way. 

This does mean that, as security, there is currently no counterplay if blood bound decide to act overtly, which is a loss. I am currently exploring ways to deconvert the blood bound that are less easy/more costly or possibly giving blood bound other advantages that security can take away through mental shielding so that they have an incentive to maintain some stealth.
## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->
Remove OnBloodBoundMindShielded and relevant deconversion string, as well as relevant system call in SharedRevolutionarySystem. 
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->
<img width="303" height="382" alt="image" src="https://github.com/user-attachments/assets/ecc07420-4f78-46ca-a6cb-a349d74c31db" />

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- tweak: Blood bound converts will no longer be deconverted when implanted with a mindshield.
