### PR TITLE
Adjust Prices on Syndicate Bombs

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -480,13 +480,13 @@
   description: uplink-exploding-syndicate-bomb-desc
   productEntity: SyndicateBomb
   cost:
-    Telecrystal: 7 #carpmosia-edit - cheaper hard bombs
+    Telecrystal: 7 # Carpmosia-edit - Cheaper hardbombs
   categories:
     - UplinkExplosives
   restockTime: 1800
   conditions:
-  - !type:ListingLimitedStockCondition #carpmosia-edit - cheaper hard bombs
-    stock: 1 #carpmosia edit - cheaper hard bombs
+  - !type:ListingLimitedStockCondition # Carpmosia-edit - Cheaper hardbombs
+    stock: 1 # Carpmosia-edit - Cheaper hardbombs
   - !type:StoreWhitelistCondition
     blacklist:
       tags:
@@ -1127,7 +1127,7 @@
   discountDownTo:
     Telecrystal: 4
   cost:
-    Telecrystal: 7 #carpmosia-edit - cheaper hard bombs
+    Telecrystal: 7 # Carpmosia-edit - Cheaper hardbombs
   categories:
   - UplinkExplosives
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -480,11 +480,13 @@
   description: uplink-exploding-syndicate-bomb-desc
   productEntity: SyndicateBomb
   cost:
-    Telecrystal: 11
+    Telecrystal: 7 #carpmosia-edit - cheaper hard bombs
   categories:
     - UplinkExplosives
   restockTime: 1800
   conditions:
+  - !type:ListingLimitedStockCondition #carpmosia-edit - cheaper hard bombs
+    stock: 1 #carpmosia edit - cheaper hard bombs
   - !type:StoreWhitelistCondition
     blacklist:
       tags:
@@ -1125,7 +1127,7 @@
   discountDownTo:
     Telecrystal: 4
   cost:
-    Telecrystal: 8
+    Telecrystal: 7 #carpmosia-edit - cheaper hard bombs
   categories:
   - UplinkExplosives
 


### PR DESCRIPTION

## General information
Lowers the prices of the Syndicate Hardbomb and Syndicate Powersink to 7 Telecrystals, as well as restricts syndicate agents to one Syndicate Bomb per uplink. Nuclear Operative uplink prices of the Hardbomb are unaffected, with the prices remaining the same. 

## Why / Balance
Upstream is moving to having Traitors move to more sabotage, and something that I've noticed was neglected in carpmosia was the ability to destroy large chunks of the station with a hardbomb. I believe the price of 11TC was too high, as it means that a traitor would have to commit to the bomb, leaving themselves without many options after. I believe that lowering the price to seven telecrystals makes the bomb a genuine use as a distraction or as a method for getting a troublesome department out of the way. 

The only issue i can see this causing is a bunch of agents placing bombs in unfortunate locations, however I believe the 30 minute timer to place a bomb helps relieve this issue. 

I hope that this leads to more agents blowing things up more often. 

## Technical details
Changed a few numbers around. 
Add a ListingLimitedStockCondition to the Syndicate Bomb in the Traitor Uplink. 

## Media

<img width="849" height="664" alt="image" src="https://github.com/user-attachments/assets/bb1e03a4-f794-4916-a0cb-e4b53a0170d7" />


Here is proof that nuclear operatives prices remain unchanged 

<img width="1154" height="894" alt="image" src="https://github.com/user-attachments/assets/fd1f90bf-ebec-4b23-b3d6-db07f7f0f8d4" />


## Breaking changes

N/A

## ChangelogAdjust Prices on Syndicate Bombs

:cl:

- tweak: Lowered the Prices of the Syndicate Anchored bombs. 

