### PR TITLE
Make salvage specialists unable to roll antag

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -10,6 +10,7 @@
   icon: "JobIconShaftMiner"
   startingGear: SalvageSpecialistGear
   supervisors: job-supervisors-qm
+  canBeAntag: false # Carpmosia-edit - No more salvage antags
   access:
   - Cargo
   - Salvage


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->

Salvage specialists can no longer roll traitor, initial infected, blood bound, etc.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->

Salvage has a lot of issues, and one of them is the state of salvage antagonists. With most other jobs, you can at least *pretend* to still be working while preparing for your nefarious shit. Meanwhile, salvage's job requires them to be off station 90% of the time if they aren't abandoning their role. This puts antag salvage specialists in a position where either they are in space just Doing Their Job, biding their time for the perfect moment (and therefore not being an active participant in the round), or they are staying on station and being incredibly obvious. Given the future of salvage is tenuous at best, and our own lack of personnel to head up a larger salvage rework, an acceptable bandaid is to simply remove the possibility of antag salvage specialists from rolling in a round. 

## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->
One line yaml change adding canBeAntag: false to salvagespecialist role
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- tweak: Salvage Specialists can no longer roll Traitor, Initial Infected, Bloodbound, Thief, or Head Revolutionary

