### PR TITLE
PA radio alerts

### DIFF
--- a/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
@@ -135,7 +135,7 @@ public sealed partial class ParticleAcceleratorControlBoxComponent : Component
     [ViewVariables]
     public bool CanBeEnabled = true;
 
-// Carpmosia-start - PA radio alerts
+    // Carpmosia-start - PA radio alerts
     /// <summary>
     /// The radio channel to broadcast on when something happens to this PA
     /// </summary>
@@ -165,6 +165,6 @@ public sealed partial class ParticleAcceleratorControlBoxComponent : Component
     /// </summary>
     [DataField]
     public LocId LocWarning = "pa-warning-broadcast";
-// Carpmosia-end - PA radio alerts
+    // Carpmosia-end - PA radio alerts
 
 }

--- a/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
@@ -146,7 +146,7 @@ public sealed partial class ParticleAcceleratorControlBoxComponent : Component
     /// Whether a radio channel should be alerted if anything happens to this PA
     /// </summary>
     [DataField]
-    public bool AlertRadio = false;
+    public bool AlertRadio = true;
 
     /// <summary>
     /// Localized string to use when this particle accelerator is activated and AlertRadio is set to true

--- a/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
@@ -1,5 +1,7 @@
 using Content.Server.ParticleAccelerator.Wires;
+using Content.Shared.Radio; // Carpmosia-edit - PA radio alerts
 using Content.Shared.Singularity.Components;
+using Robust.Shared.Prototypes; // Carpmosia-edit - PA radio alerts
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.ParticleAccelerator.Components;
@@ -132,4 +134,37 @@ public sealed partial class ParticleAcceleratorControlBoxComponent : Component
     /// </summary>
     [ViewVariables]
     public bool CanBeEnabled = true;
+
+// Carpmosia-start - PA radio alerts
+    /// <summary>
+    /// The radio channel to broadcast on when something happens to this PA
+    /// </summary>
+    [DataField]
+    public ProtoId<RadioChannelPrototype> RadioChannel = "Engineering";
+
+    /// <summary>
+    /// Whether a radio channel should be alerted if anything happens to this PA
+    /// </summary>
+    [DataField]
+    public bool AlertRadio = false;
+
+    /// <summary>
+    /// Localized string to use when this particle accelerator is activated and AlertRadio is set to true
+    /// </summary>
+    [DataField]
+    public LocId LocActivated = "pa-activated-broadcast";
+
+    /// <summary>
+    /// Localized string to use when this particle accelerator is deactivated and AlertRadio is set to true
+    /// </summary>
+    [DataField]
+    public LocId LocDeactivated = "pa-deactivated-broadcast";
+
+    /// <summary>
+    /// Localized string to use when this particle accelerator is set above a certain strength and AlertRadio is set to true
+    /// </summary>
+    [DataField]
+    public LocId LocWarning = "pa-warning-broadcast";
+// Carpmosia-end - PA radio alerts
+
 }

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
@@ -132,7 +132,7 @@ public sealed partial class ParticleAcceleratorSystem
         UpdatePartVisualStates(uid, comp);
         UpdateUI(uid, comp);
 
-        AlertRadio(comp, comp.LocActivated); // Carpmosia-edit - PA radio alerts
+        AlertRadio((uid, comp), comp.LocActivated); // Carpmosia-edit - PA radio alerts
     }
 
     public void PowerOff(EntityUid uid, ParticleAcceleratorControlBoxComponent? comp = null)
@@ -148,7 +148,7 @@ public sealed partial class ParticleAcceleratorSystem
         UpdatePartVisualStates(uid, comp);
         UpdateUI(uid, comp);
 
-        AlertRadio(comp, comp.LocDeactivated); // Carpmosia-edit - PA radio alerts
+        AlertRadio((uid, comp), comp.LocDeactivated); // Carpmosia-edit - PA radio alerts
     }
 
     public void SetStrength(EntityUid uid, ParticleAcceleratorPowerState strength, EntityUid? user = null, ParticleAcceleratorControlBoxComponent? comp = null)
@@ -200,7 +200,7 @@ public sealed partial class ParticleAcceleratorSystem
                     comp.EffectCooldown = _gameTiming.CurTime + comp.CooldownDuration;
                 }
 
-                AlertRadio(comp, comp.LocWarning); // Carpmosia-edit - PA radio alerts
+                AlertRadio((uid, comp), comp.LocWarning); // Carpmosia-edit - PA radio alerts
             }
         }
 
@@ -446,13 +446,13 @@ public sealed partial class ParticleAcceleratorSystem
     }
 
     // Carpmosia-start - PA radio alerts
-    private void AlertRadio(ParticleAcceleratorControlBoxComponent comp, string locString)
+    private void AlertRadio(Entity<ParticleAcceleratorControlBoxComponent> comp, string locString)
     {
-        if (!comp.AlertRadio)
+        if (!comp.Comp.AlertRadio)
             return; // APEs do not need to scream over engineering radio, and an emitter that is off is probably not going to be alerting radios
 
         var message = Loc.GetString(locString);
-        _radio.SendRadioMessage(comp.Owner, message, comp.RadioChannel, comp.Owner);
+        _radio.SendRadioMessage(comp.Owner, message, comp.Comp.RadioChannel, comp.Owner);
     }
     // Carpmosia-end - PA radio alerts
 }

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
@@ -1,5 +1,6 @@
 using Content.Server.ParticleAccelerator.Components;
 using Content.Server.Power.Components;
+using Content.Server.Radio.EntitySystems; // Carpmosia-edit - PA radio alerts
 using Content.Shared.Database;
 using Content.Shared.Machines.Components;
 using Content.Shared.Singularity.Components;
@@ -20,6 +21,7 @@ public sealed partial class ParticleAcceleratorSystem
 {
     [Dependency] private readonly IAdminManager _adminManager = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly RadioSystem _radio = default!; // Carpmosia-edit - PA radio alerts
 
     private void InitializeControlBoxSystem()
     {
@@ -129,6 +131,8 @@ public sealed partial class ParticleAcceleratorSystem
         UpdateFiring(uid, comp);
         UpdatePartVisualStates(uid, comp);
         UpdateUI(uid, comp);
+
+        AlertRadio(comp, comp.LocActivated); // Carpmosia-edit - PA radio alerts
     }
 
     public void PowerOff(EntityUid uid, ParticleAcceleratorControlBoxComponent? comp = null)
@@ -143,6 +147,8 @@ public sealed partial class ParticleAcceleratorSystem
         UpdateFiring(uid, comp);
         UpdatePartVisualStates(uid, comp);
         UpdateUI(uid, comp);
+
+        AlertRadio(comp, comp.LocDeactivated); // Carpmosia-edit - PA radio alerts
     }
 
     public void SetStrength(EntityUid uid, ParticleAcceleratorPowerState strength, EntityUid? user = null, ParticleAcceleratorControlBoxComponent? comp = null)
@@ -193,6 +199,8 @@ public sealed partial class ParticleAcceleratorSystem
                         AudioParams.Default.WithVolume(-8f));
                     comp.EffectCooldown = _gameTiming.CurTime + comp.CooldownDuration;
                 }
+
+                AlertRadio(comp, comp.LocWarning); // Carpmosia-edit - PA radio alerts
             }
         }
 
@@ -436,4 +444,15 @@ public sealed partial class ParticleAcceleratorSystem
             _ => 0
         };
     }
+
+// Carpmosia-start - PA radio alerts
+        private void AlertRadio(ParticleAcceleratorControlBoxComponent comp, string locString)
+        {
+            if (!comp.AlertRadio)
+                return; // APEs do not need to scream over engineering radio, and an emitter that is off is probably not going to be alerting radios
+
+            var message = Loc.GetString(locString);
+            _radio.SendRadioMessage(comp.Owner, message, comp.RadioChannel, comp.Owner);
+        }
+// Carpmosia-end - PA radio alerts
 }

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
@@ -446,13 +446,13 @@ public sealed partial class ParticleAcceleratorSystem
     }
 
     // Carpmosia-start - PA radio alerts
-    private void AlertRadio(Entity<ParticleAcceleratorControlBoxComponent> comp, string locString)
+    private void AlertRadio(Entity<ParticleAcceleratorControlBoxComponent> ent, string locString)
     {
-        if (!comp.Comp.AlertRadio)
-            return; // APEs do not need to scream over engineering radio, and an emitter that is off is probably not going to be alerting radios
+        if (!ent.Comp.AlertRadio)
+            return;
 
         var message = Loc.GetString(locString);
-        _radio.SendRadioMessage(comp.Owner, message, comp.Comp.RadioChannel, comp.Owner);
+        _radio.SendRadioMessage(ent.Owner, message, ent.Comp.RadioChannel, ent.Owner);
     }
     // Carpmosia-end - PA radio alerts
 }

--- a/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
+++ b/Content.Server/ParticleAccelerator/EntitySystems/ParticleAcceleratorSystem.ControlBox.cs
@@ -445,14 +445,14 @@ public sealed partial class ParticleAcceleratorSystem
         };
     }
 
-// Carpmosia-start - PA radio alerts
-        private void AlertRadio(ParticleAcceleratorControlBoxComponent comp, string locString)
-        {
-            if (!comp.AlertRadio)
-                return; // APEs do not need to scream over engineering radio, and an emitter that is off is probably not going to be alerting radios
+    // Carpmosia-start - PA radio alerts
+    private void AlertRadio(ParticleAcceleratorControlBoxComponent comp, string locString)
+    {
+        if (!comp.AlertRadio)
+            return; // APEs do not need to scream over engineering radio, and an emitter that is off is probably not going to be alerting radios
 
-            var message = Loc.GetString(locString);
-            _radio.SendRadioMessage(comp.Owner, message, comp.RadioChannel, comp.Owner);
-        }
-// Carpmosia-end - PA radio alerts
+        var message = Loc.GetString(locString);
+        _radio.SendRadioMessage(comp.Owner, message, comp.RadioChannel, comp.Owner);
+    }
+    // Carpmosia-end - PA radio alerts
 }

--- a/Resources/Locale/en-US/_Carpmosia/singularity/components/generator-component.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/singularity/components/generator-component.ftl
@@ -1,0 +1,5 @@
+### GeneratorComponent
+
+pa-activated-broadcast = Alert! The Particle Accelerator has been activated.
+pa-deactivated-broadcast = Alert! The Particle Accelerator has been deactivated.
+pa-warning-broadcast = Warning! The Particle Accelerator is exceeding safe operational parameters!

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
@@ -7,7 +7,6 @@
   - type: Sprite
     sprite: Structures/Power/Generation/PA/control_box.rsi
   - type: ParticleAcceleratorControlBox
-    alertRadio: true # Carpmosia-edit - PA radio alerts
   - type: ApcPowerReceiver
     powerLoad: 250
   - type: ExtensionCableReceiver

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/PA/control_box.yml
@@ -7,6 +7,7 @@
   - type: Sprite
     sprite: Structures/Power/Generation/PA/control_box.rsi
   - type: ParticleAcceleratorControlBox
+    alertRadio: true # Carpmosia-edit - PA radio alerts
   - type: ApcPowerReceiver
     powerLoad: 250
   - type: ExtensionCableReceiver


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Adds radio alerts for when the PA is turned off and on, as well as if the PA strength is set to 4 (the one accessed by cutting a wire).
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Part of the work for https://github.com/carpmosia/carpmosia/issues/326. Makes PA sabotage no longer a silent bit of sabotage someone can do to wreck the station one way or another (either through killing an engine or loosing it).
## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->
Added a method to the ParticleAcceleratorBoxSystem for sending radio alerts and added some loc strings to the component. (Most of this stuff is ripped from the Emitters)
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->
<img width="1019" height="586" alt="image" src="https://github.com/user-attachments/assets/d28c38f5-59d7-4445-ab19-2ccb96975a35" />

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->
None that I'm aware of.
## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- add: The particle accelerator will now alert engineering if it is activated, deactivated, or if it's strength is set to 4.
