### PR TITLE
Remove Tonguebiting

### DIFF
--- a/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
+++ b/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
@@ -79,6 +79,7 @@ public sealed class SuicideCommandTests : GameTest
         var playerMan = server.ResolveDependency<IPlayerManager>();
         var mindSystem = entManager.System<SharedMindSystem>();
         var mobStateSystem = entManager.System<MobStateSystem>();
+        var tagSystem = entManager.System<TagSystem>();
 
         // We need to know the player and whether they can be hurt, killed, and whether they have a mind
         var player = playerMan.Sessions.First().AttachedEntity!.Value;
@@ -123,6 +124,7 @@ public sealed class SuicideCommandTests : GameTest
         var entManager = server.ResolveDependency<IEntityManager>();
         var playerMan = server.ResolveDependency<IPlayerManager>();
         var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var tagSystem = entManager.System<TagSystem>();
 
         var damageableSystem = entManager.System<DamageableSystem>();
         var mindSystem = entManager.System<SharedMindSystem>();
@@ -299,6 +301,7 @@ public sealed class SuicideCommandTests : GameTest
         var mobStateSystem = entManager.System<MobStateSystem>();
         var transformSystem = entManager.System<TransformSystem>();
         var damageableSystem = entManager.System<DamageableSystem>();
+        var tagSystem = entManager.System<TagSystem>();
 
         // We need to know the player and whether they can be hurt, killed, and whether they have a mind
         var player = playerMan.Sessions.First().AttachedEntity!.Value;

--- a/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
+++ b/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
@@ -231,7 +231,7 @@ public sealed class SuicideCommandTests : GameTest
         var mobStateSystem = entManager.System<MobStateSystem>();
         var transformSystem = entManager.System<TransformSystem>();
         var damageableSystem = entManager.System<DamageableSystem>();
-        var tagSystem = entManager.System<TagSystem>();
+        var tagSystem = entManager.System<TagSystem>(); // Carpmosia-edit - Remove Tonguebiting
 
         // We need to know the player and whether they can be hurt, killed, and whether they have a mind
         var player = playerMan.Sessions.First().AttachedEntity!.Value;
@@ -302,7 +302,7 @@ public sealed class SuicideCommandTests : GameTest
         var mobStateSystem = entManager.System<MobStateSystem>();
         var transformSystem = entManager.System<TransformSystem>();
         var damageableSystem = entManager.System<DamageableSystem>();
-        var tagSystem = entManager.System<TagSystem>();
+        var tagSystem = entManager.System<TagSystem>(); // Carpmosia-edit - Remove Tonguebiting
 
         // We need to know the player and whether they can be hurt, killed, and whether they have a mind
         var player = playerMan.Sessions.First().AttachedEntity!.Value;

--- a/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
+++ b/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
@@ -79,7 +79,7 @@ public sealed class SuicideCommandTests : GameTest
         var playerMan = server.ResolveDependency<IPlayerManager>();
         var mindSystem = entManager.System<SharedMindSystem>();
         var mobStateSystem = entManager.System<MobStateSystem>();
-        var tagSystem = entManager.System<TagSystem>();
+        var tagSystem = entManager.System<TagSystem>(); // Carpmosia-edit - Remove Tonguebiting
 
         // We need to know the player and whether they can be hurt, killed, and whether they have a mind
         var player = playerMan.Sessions.First().AttachedEntity!.Value;
@@ -124,7 +124,7 @@ public sealed class SuicideCommandTests : GameTest
         var entManager = server.ResolveDependency<IEntityManager>();
         var playerMan = server.ResolveDependency<IPlayerManager>();
         var protoMan = server.ResolveDependency<IPrototypeManager>();
-        var tagSystem = entManager.System<TagSystem>();
+        var tagSystem = entManager.System<TagSystem>(); // Carpmosia-edit - Remove Tonguebiting
 
         var damageableSystem = entManager.System<DamageableSystem>();
         var mindSystem = entManager.System<SharedMindSystem>();

--- a/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
+++ b/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
@@ -231,6 +231,7 @@ public sealed class SuicideCommandTests : GameTest
         var mobStateSystem = entManager.System<MobStateSystem>();
         var transformSystem = entManager.System<TransformSystem>();
         var damageableSystem = entManager.System<DamageableSystem>();
+        var tagSystem = entManager.System<TagSystem>();
 
         // We need to know the player and whether they can be hurt, killed, and whether they have a mind
         var player = playerMan.Sessions.First().AttachedEntity!.Value;

--- a/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
+++ b/Content.IntegrationTests/Tests/Commands/SuicideCommandTests.cs
@@ -94,6 +94,7 @@ public sealed class SuicideCommandTests : GameTest
             mobStateComp = entManager.GetComponent<MobStateComponent>(player);
         });
 
+        tagSystem.RemoveTag(player, CannotSuicideTag); // Carpmosia-edit - Remove Tonguebiting
 
         // Check that running the suicide command kills the player
         // and properly ghosts them without them being able to return to their body
@@ -145,6 +146,8 @@ public sealed class SuicideCommandTests : GameTest
             var slashProto = protoMan.Index(DamageType);
             damageableSystem.TryChangeDamage(player, new DamageSpecifier(slashProto, FixedPoint2.New(46.5)));
         });
+
+        tagSystem.RemoveTag(player, CannotSuicideTag); // Carpmosia-edit - Remove Tonguebiting
 
         // Check that running the suicide command kills the player
         // and properly ghosts them without them being able to return to their body
@@ -256,6 +259,8 @@ public sealed class SuicideCommandTests : GameTest
             Assert.That(executionComponent, Is.Not.EqualTo(null));
         });
 
+        tagSystem.RemoveTag(player, CannotSuicideTag); // Carpmosia-edit - Remove Tonguebiting
+
         // Check that running the suicide command kills the player
         // and properly ghosts them without them being able to return to their body
         // and that all the damage is concentrated in the Slash category
@@ -323,6 +328,8 @@ public sealed class SuicideCommandTests : GameTest
             entManager.TryGetComponent<ExecutionComponent>(item, out var executionComponent);
             Assert.That(executionComponent, Is.Not.EqualTo(null));
         });
+
+        tagSystem.RemoveTag(player, CannotSuicideTag); // Carpmosia-edit - Remove Tonguebiting
 
         // Check that running the suicide command kills the player
         // and properly ghosts them without them being able to return to their body

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -158,6 +158,7 @@
     - FootstepSound
     - DoorBumpOpener
     - AnomalyHost
+    - CannotSuicide
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -158,7 +158,7 @@
     - FootstepSound
     - DoorBumpOpener
     - AnomalyHost
-    - CannotSuicide
+    - CannotSuicide # Carpmosia-edit - Remove Tonguebiting
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
/Suicide will now cause you to ghost instead of bite your tongue.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Requested admin change. Usually only done by shitters or people looking to do a joke in poor taste. I will miss shoving myself in the microwave but we all have to make sacrifices.
## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->
One line yaml tag addition to base mob.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->
None I think?
## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- tweak: The /suicide command will now cause you to ghost instead.
