### PR TITLE
Hit secret weights with hammers

### DIFF
--- a/Resources/Prototypes/_Carpmosia/secret_weights.yml
+++ b/Resources/Prototypes/_Carpmosia/secret_weights.yml
@@ -1,9 +1,9 @@
 - type: weightedRandom
   id: CarpmosiaSecret
   weights:
-    Traitor: 45 # minPlayers 5
-    Nukeops: 20 # minPlayers 20
-    Xenoborgs: 15 # minPlayers 20
+    Nukeops: 25 # minPlayers 20
+    Xenoborgs: 25 # minPlayers 20
+    Traitor: 20 # minPlayers 5
     Survival: 10 # minPlayers 0
-    Revolutionary: 5 # minPlayers 15
-    Zombie: 5 # minPlayers 20
+    Revolutionary: 10 # minPlayers 15
+    Zombie: 10 # minPlayers 20


### PR DESCRIPTION
## General information
Pulverizes the Traitors preset weight in favor of every other god damned game mode.

## Why / Balance
The average carpmos traitor does absolutely nothing antagonistic the entire round.
On average carpmos literally always rolls traitors because the population doesn't let anything else spawn, and when it does, it rolls traitors anyway because it's got a ridiculously high weight for no good reason.
The average carpmos round is, informally, a greenshift. (As opposed to formally a greenshift using the Greenshift preset).

Literally everyone I asked about this asked me to do it.

## Technical details
One table.

## Media
NukeOps 25% - Xenoborgs 25% - Traitors 20% - Survival 10% - Revolution 10% - Zombies 10%
<img width="512" height="165" alt="image" src="https://github.com/user-attachments/assets/7a857ba0-ea60-46c8-9dd9-92ffd16042c2" />

## Breaking changes
Rounds have antagonists now it's completely unplayable.

## Changelog
:cl:
- tweak: The Secret gamemode weight has been edited. At 20 players ready, the chances are: 
NukeOps 25% - Xenoborgs 25% - Traitors 20% - Survival 10% - Revolution 10% - Zombies 10%