### PR TITLE
Cargo armory no more

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -1,79 +1,79 @@
-- type: cargoProduct
-  id: ArmorySmg
-  icon:
-    sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
-    state: icon
-  product: CrateArmorySMG
-  cost: 9000
-  category: cargoproduct-category-name-armory
-  group: market
+# - type: cargoProduct
+#   id: ArmorySmg
+#   icon:
+#     sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
+#     state: icon
+#   product: CrateArmorySMG
+#   cost: 9000
+#   category: cargoproduct-category-name-armory
+#   group: market
 
-- type: cargoProduct
-  id: ArmoryShotgun
-  icon:
-    sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
-    state: icon
-  product: CrateArmoryShotgun
-  cost: 7000
-  category: cargoproduct-category-name-armory
-  group: market
+# - type: cargoProduct
+#   id: ArmoryShotgun
+#   icon:
+#     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
+#     state: icon
+#   product: CrateArmoryShotgun
+#   cost: 7000
+#   category: cargoproduct-category-name-armory
+#   group: market
 
-- type: cargoProduct
-  id: SecurityRiot
-  icon:
-    sprite: Clothing/OuterClothing/Armor/riot.rsi
-    state: icon
-  product: CrateSecurityRiot
-  cost: 7500
-  category: cargoproduct-category-name-armory
-  group: market
+# - type: cargoProduct
+#   id: SecurityRiot
+#   icon:
+#     sprite: Clothing/OuterClothing/Armor/riot.rsi
+#     state: icon
+#   product: CrateSecurityRiot
+#   cost: 7500
+#   category: cargoproduct-category-name-armory
+#   group: market
 
-- type: cargoProduct
-  id: TrackingImplant
-  icon:
-    sprite: Objects/Specific/Medical/implanter.rsi
-    state: implanter0
-  product: CrateTrackingImplants
-  cost: 1000
-  category: cargoproduct-category-name-armory
-  group: market
+# - type: cargoProduct
+#   id: TrackingImplant
+#   icon:
+#     sprite: Objects/Specific/Medical/implanter.rsi
+#     state: implanter0
+#   product: CrateTrackingImplants
+#   cost: 1000
+#   category: cargoproduct-category-name-armory
+#   group: market
 
-- type: cargoProduct
-  id: TrainingBombs
-  icon:
-    sprite: Structures/Machines/bomb.rsi
-    state: training-bomb
-  product: CrateTrainingBombs
-  cost: 3000
-  category: cargoproduct-category-name-armory
-  group: market
+# - type: cargoProduct
+#   id: TrainingBombs
+#   icon:
+#     sprite: Structures/Machines/bomb.rsi
+#     state: training-bomb
+#   product: CrateTrainingBombs
+#   cost: 3000
+#   category: cargoproduct-category-name-armory
+#   group: market
 
-- type: cargoProduct
-  id: ArmoryLaser
-  icon:
-    sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
-    state: icon
-  product: CrateArmoryLaser
-  cost: 4800
-  category: cargoproduct-category-name-armory
-  group: market
+# - type: cargoProduct
+#   id: ArmoryLaser
+#   icon:
+#     sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
+#     state: icon
+#   product: CrateArmoryLaser
+#   cost: 4800
+#   category: cargoproduct-category-name-armory
+#   group: market
 
-- type: cargoProduct
-  id: ArmoryPistol
-  icon:
-    sprite: Objects/Weapons/Guns/Pistols/mk58.rsi
-    state: icon
-  product: CrateArmoryPistols
-  cost: 5200
-  category: cargoproduct-category-name-armory
-  group: market
+# - type: cargoProduct
+#   id: ArmoryPistol
+#   icon:
+#     sprite: Objects/Weapons/Guns/Pistols/mk58.rsi
+#     state: icon
+#   product: CrateArmoryPistols
+#   cost: 5200
+#   category: cargoproduct-category-name-armory
+#   group: market
 
-- type: cargoProduct
-  id: ArmoryRifle
-  icon:
-    sprite: Objects/Weapons/Guns/Rifles/lecter.rsi
-    state: icon
-  product: CrateArmoryRifle
-  cost: 8000
-  category: cargoproduct-category-name-armory
-  group: market
+# - type: cargoProduct
+#   id: ArmoryRifle
+#   icon:
+#     sprite: Objects/Weapons/Guns/Rifles/lecter.rsi
+#     state: icon
+#   product: CrateArmoryRifle
+#   cost: 8000
+#   category: cargoproduct-category-name-armory
+#   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -1,4 +1,4 @@
-# Carpmosia-rework - Remove Cargo Armory
+# Carpmosia-start - Remove Cargo Armory
 # - type: cargoProduct
 #   id: ArmorySmg
 #   icon:
@@ -80,3 +80,4 @@
 #   cost: 8000
 #   category: cargoproduct-category-name-armory
 #   group: market
+# Carpmosia-end - Remove Cargo Armory

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -28,27 +28,29 @@
 #   cost: 7500
 #   category: cargoproduct-category-name-armory
 #   group: market
+# Carpmosia-end - Remove Cargo Armory
 
-# - type: cargoProduct
-#   id: TrackingImplant
-#   icon:
-#     sprite: Objects/Specific/Medical/implanter.rsi
-#     state: implanter0
-#   product: CrateTrackingImplants
-#   cost: 1000
-#   category: cargoproduct-category-name-armory
-#   group: market
+- type: cargoProduct
+  id: TrackingImplant
+  icon:
+    sprite: Objects/Specific/Medical/implanter.rsi
+    state: implanter0
+  product: CrateTrackingImplants
+  cost: 1000
+  category: cargoproduct-category-name-armory
+  group: market
 
-# - type: cargoProduct
-#   id: TrainingBombs
-#   icon:
-#     sprite: Structures/Machines/bomb.rsi
-#     state: training-bomb
-#   product: CrateTrainingBombs
-#   cost: 3000
-#   category: cargoproduct-category-name-armory
-#   group: market
+- type: cargoProduct
+  id: TrainingBombs
+  icon:
+    sprite: Structures/Machines/bomb.rsi
+    state: training-bomb
+  product: CrateTrainingBombs
+  cost: 3000
+  category: cargoproduct-category-name-armory
+  group: market
 
+# Carpmosia-start - Remove Cargo Armory
 # - type: cargoProduct
 #   id: ArmoryLaser
 #   icon:

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -1,4 +1,4 @@
-# Carpmosia-start - Remove Cargo Armory
+# Carpmosia-rework - Remove Cargo Armory
 # - type: cargoProduct
 #   id: ArmorySmg
 #   icon:
@@ -78,4 +78,3 @@
 #   cost: 8000
 #   category: cargoproduct-category-name-armory
 #   group: market
-# Carpmosia-end - Remove Cargo Armory

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -1,3 +1,4 @@
+# Carpmosia-start - Remove Cargo Armory
 # - type: cargoProduct
 #   id: ArmorySmg
 #   icon:
@@ -77,3 +78,4 @@
 #   cost: 8000
 #   category: cargoproduct-category-name-armory
 #   group: market
+# Carpmosia-end - Remove Cargo Armory

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -10,8 +10,8 @@
     - id: GiftsMedical
     - id: GiftsPizzaPartyLarge
     - id: GiftsPizzaPartySmall
-    - id: GiftsSecurityGuns
-    - id: GiftsSecurityRiot
+    # - id: GiftsSecurityGuns
+    # - id: GiftsSecurityRiot
     - id: GiftsSpacingSupplies
     - id: GiftsVendingRestock
 
@@ -198,20 +198,20 @@
 #       ArmoryLaser: 1
 #       ArmoryRifle: 1
 
-- type: entity
-  id: GiftsSecurityRiot
-  parent: CargoGiftsBase
-  components:
-  - type: StationEvent
-    weight: 4
-    duration: 120
-    earliestStart: 20
-    minimumPlayers: 50
-  - type: CargoGiftsRule
-    description: cargo-gift-security-riot
-    dest: cargo-gift-dest-sec
-    gifts:
-      SecurityRiot: 2
-      SecurityRestraints: 2
-      SecurityNonLethal: 2
-      SecurityNonlethalThrowables: 1
+# - type: entity
+#   id: GiftsSecurityRiot
+#   parent: CargoGiftsBase
+#   components:
+#   - type: StationEvent
+#     weight: 4
+#     duration: 120
+#     earliestStart: 20
+#     minimumPlayers: 50
+#   - type: CargoGiftsRule
+#     description: cargo-gift-security-riot
+#     dest: cargo-gift-dest-sec
+#     gifts:
+#       SecurityRiot: 2
+#       SecurityRestraints: 2
+#       SecurityNonLethal: 2
+#       SecurityNonlethalThrowables: 1

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -179,6 +179,7 @@
       EmergencyBurnKit: 1
       EmergencyBruteKit: 1
 
+# Carpmosia-start - Remove Cargo Armory
 # - type: entity
 #   id: GiftsSecurityGuns
 #   parent: CargoGiftsBase
@@ -215,3 +216,4 @@
 #       SecurityRestraints: 2
 #       SecurityNonLethal: 2
 #       SecurityNonlethalThrowables: 1
+# Carpmosia-end - Remove Cargo Armory

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -179,24 +179,24 @@
       EmergencyBurnKit: 1
       EmergencyBruteKit: 1
 
-- type: entity
-  id: GiftsSecurityGuns
-  parent: CargoGiftsBase
-  components:
-  - type: StationEvent
-    weight: 3
-    duration: 120
-    earliestStart: 20
-    minimumPlayers: 50
-  - type: CargoGiftsRule
-    description: cargo-gift-security-guns
-    dest: cargo-gift-dest-sec
-    gifts:
-      SecurityArmor: 3
-      ArmorySmg: 1
-      ArmoryShotgun: 1
-      ArmoryLaser: 1
-      ArmoryRifle: 1
+# - type: entity
+#   id: GiftsSecurityGuns
+#   parent: CargoGiftsBase
+#   components:
+#   - type: StationEvent
+#     weight: 3
+#     duration: 120
+#     earliestStart: 20
+#     minimumPlayers: 50
+#   - type: CargoGiftsRule
+#     description: cargo-gift-security-guns
+#     dest: cargo-gift-dest-sec
+#     gifts:
+#       SecurityArmor: 3
+#       ArmorySmg: 1
+#       ArmoryShotgun: 1
+#       ArmoryLaser: 1
+#       ArmoryRifle: 1
 
 - type: entity
   id: GiftsSecurityRiot

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -10,8 +10,10 @@
     - id: GiftsMedical
     - id: GiftsPizzaPartyLarge
     - id: GiftsPizzaPartySmall
+    # Carpmosia-start - Remove Cargo Armory
     # - id: GiftsSecurityGuns
     # - id: GiftsSecurityRiot
+    # Carpmosia-end - Remove Cargo Armory
     - id: GiftsSpacingSupplies
     - id: GiftsVendingRestock
 


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Removes armory orders from the cargo request listings.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Part of a general rethink in balancing, primarily for things like Traitors. The main reason for keeping armory orders in my view is to prevent a very boring nukeop strategy of armory-holding/armory-spacing. Basically, if the nukies get ahold of the whole armory and manage to toss it into space or otherwise prevent the crew from arming, they can win rather easily. Cargo can take over for security in this instance and essentially *become* the armory. This *is* a situation we want to disincentivize, as crew getting a chance to fight back is going to lead to a more interesting round then the checkmate situation I describe above.

The cost of this feature is that: 
- Cargo can take over for security in *any* situation, including in situations where it isn't prudent
- Non-security, non-antagonists can get access to equipment they really, really shouldn't have (enforcer crate salvagers cough cough)
- Skews the balance of non-nukie antagonist rounds by making weapons and armor very easily acquired. This is a problem for https://github.com/carpmosia/carpmosia/issues/331 and even slightly with the rewritten rules. We want to free antagonists from the burden of having to worry about excessive destruction, and part of that is removing ways they can easily dominate the station and its crew. This is one part of that.

I have come to believe the cost is too high, and so ultimately, armory crates are gone. I do think security should have ways to replenish their arms that don't rely on armory science, so it may be a good idea to add something to the armory techfab. Maybe basic laser carbines can be printed roundstart or something. 

Enforcers also are more or less gone unless mapped now, which is unfortunate.
 
## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->
Commented out a buncha yaml
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- remove: The armory catalogue in the cargo request computer has been removed.

