### PR TITLE
Scalpels in Boots

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -90,6 +90,12 @@
         Slash: 8
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
+  # Carpmosia-start - Scalpels in boots
+  - type: Tag
+    tags:
+    - SurgeryTool
+    - Knife
+  # Carpmosia-end - Scalpels in boots
 
 - type: entity
   name: shiv


### PR DESCRIPTION
## General information
Small tweak to scalpels that allows for scalpels to be stored inside of boots by giving them the knife tag

## Why / Balance
Scalpels are small knives, it makes sense from them to be storeable in boots. Would have negligible effects on balance as all it does is free up two storage slots for (primarily) medical roles. While other roles *could* use this feature, scalpels are a pretty weak weapon and are mainly used for butchering.

## Technical details
Added the knife tag to scalpels

## Test plan
I spawned in a pair of cowboy boots and a scalpel, equipped the boots, inserted and ejected the scalpel. No issues.

## Changelog
:cl:
- add: Scalpels can now be stored in shoes with items slots (e.g. Jackboots, Cowboy Boots, et cetera).
