### PR TITLE
Downturn the recycler EMAG interaction

### DIFF
--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -26,8 +26,8 @@ using Robust.Shared.Utility;
 using System.Linq;
 using Content.Shared.Gibbing;
 using Content.Shared.Humanoid;
-using Content.Shared.Damage.Components; // using Content.Shared.Gibbing; Carpmosia-edit - Survivable recyclers
-using Content.Shared.Damage.Systems; // using Content.Shared.Gibbing; Carpmosia-edit - Survivable recyclers
+using Content.Shared.Damage.Components; // Carpmosia-edit - Survivable recyclers
+using Content.Shared.Damage.Systems; // Carpmosia-edit - Survivable recyclers
 
 namespace Content.Server.Materials;
 
@@ -189,11 +189,11 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
         if (component.ReclaimMaterials)
             SpawnMaterialsFromComposition(uid, item, completion * component.Efficiency, xform: xform);
 
-        // Carpmosia-start - Survivable recyclers
-        bool deleteItem = true;
+        bool deleteItem = true; // Carpmosia-edit - Survivable recyclers
 
         if (CanGib(uid, item, component))
         {
+        // Carpmosia-start - Survivable recyclers
             var logImpact = HasComp<HumanoidProfileComponent>(item) ? LogImpact.Extreme : LogImpact.Medium;
             _adminLogger.Add(LogType.Gib, logImpact, $"{ToPrettyString(item):victim} was minced by {ToPrettyString(uid):entity} ");
             _damage.TryChangeDamage(item, component.Damage);
@@ -219,8 +219,8 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
         RaiseLocalEvent(uid, ref ev);
         // Carpmosia-end - Salvage Tickets
 
-        if (deleteItem)
-            QueueDel(item);
+        if (deleteItem) // Carpmosia-edit - Survivable recyclers
+            QueueDel(item); // Carpmosia-edit - Survivable recyclers
     }
 
     private void SpawnMaterialsFromComposition(EntityUid reclaimer,

--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -199,14 +199,6 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
             _damage.TryChangeDamage(item, component.Damage);
             _appearance.SetData(uid, RecyclerVisuals.Bloody, true);
             deleteItem = false;
-        /*
-            var logImpact = HasComp<HumanoidProfileComponent>(item) ? LogImpact.Extreme : LogImpact.Medium;
-            _adminLogger.Add(LogType.Gib, logImpact, $"{ToPrettyString(item):victim} was gibbed by {ToPrettyString(uid):entity} ");
-            if (component.ReclaimSolutions)
-                SpawnChemicalsFromComposition(uid, item, completion, false, component, xform);
-            _gibbing.Gib(item);
-            _appearance.SetData(uid, RecyclerVisuals.Bloody, true);
-        */
         // Carpmosia-end - Survivable recyclers
         }
         else

--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -26,6 +26,8 @@ using Robust.Shared.Utility;
 using System.Linq;
 using Content.Shared.Gibbing;
 using Content.Shared.Humanoid;
+using Content.Shared.Damage.Components; // using Content.Shared.Gibbing; Carpmosia-edit - Survivable recyclers
+using Content.Shared.Damage.Systems; // using Content.Shared.Gibbing; Carpmosia-edit - Survivable recyclers
 
 namespace Content.Server.Materials;
 
@@ -44,6 +46,7 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
     [Dependency] private StackSystem _stack = default!;
     [Dependency] private SharedMindSystem _mind = default!;
     [Dependency] private IAdminLogManager _adminLogger = default!;
+    [Dependency] private DamageableSystem _damage = default!; // Carpmosia-edit - Survivable recyclers
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -186,14 +189,25 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
         if (component.ReclaimMaterials)
             SpawnMaterialsFromComposition(uid, item, completion * component.Efficiency, xform: xform);
 
+        // Carpmosia-start - Survivable recyclers
+        bool deleteItem = true;
+
         if (CanGib(uid, item, component))
         {
+            var logImpact = HasComp<HumanoidProfileComponent>(item) ? LogImpact.Extreme : LogImpact.Medium;
+            _adminLogger.Add(LogType.Gib, logImpact, $"{ToPrettyString(item):victim} was minced by {ToPrettyString(uid):entity} ");
+            _damage.TryChangeDamage(item, component.Damage);
+            _appearance.SetData(uid, RecyclerVisuals.Bloody, true);
+            deleteItem = false;
+        /*
             var logImpact = HasComp<HumanoidProfileComponent>(item) ? LogImpact.Extreme : LogImpact.Medium;
             _adminLogger.Add(LogType.Gib, logImpact, $"{ToPrettyString(item):victim} was gibbed by {ToPrettyString(uid):entity} ");
             if (component.ReclaimSolutions)
                 SpawnChemicalsFromComposition(uid, item, completion, false, component, xform);
             _gibbing.Gib(item);
             _appearance.SetData(uid, RecyclerVisuals.Bloody, true);
+        */
+        // Carpmosia-end - Survivable recyclers
         }
         else
         {
@@ -205,7 +219,8 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
         RaiseLocalEvent(uid, ref ev);
         // Carpmosia-end - Salvage Tickets
 
-        QueueDel(item);
+        if (deleteItem)
+            QueueDel(item);
     }
 
     private void SpawnMaterialsFromComposition(EntityUid reclaimer,

--- a/Content.Shared/Materials/MaterialReclaimerComponent.cs
+++ b/Content.Shared/Materials/MaterialReclaimerComponent.cs
@@ -4,6 +4,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Content.Shared.Damage; // Carpmosia-edit - Survivable recyclers
 
 namespace Content.Shared.Materials;
 
@@ -137,6 +138,14 @@ public sealed partial class MaterialReclaimerComponent : Component
     /// </remarks>
     [DataField, AutoNetworkedField]
     public int ItemsProcessed;
+
+    // Carpmosia-start - Survivable recyclers
+    /// <summary>
+    /// Damage to deal to entities when emagged
+    /// </summary>
+    [DataField]
+    public DamageSpecifier Damage = default!;
+    // Carpmosia-end - Survivable recyclers
 }
 
 [NetSerializable, Serializable]

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -61,6 +61,11 @@
 
   - type: CollideMaterialReclaimer
   - type: MaterialReclaimer
+    # Carpmosia-start - Survivable recyclers
+    damage:
+      types:
+        Slash: 50 # TODO: because it relies on a physics interaction this procs more than once. the intended damage is 100 slash. i couldn't get it to happen more than twice at a time on humanoids so 50 it is
+    # Carpmosia-end - Survivable recyclers
     enabled: false
     scaleProcessSpeed: false #instant!
     minimumProcessDuration: 0


### PR DESCRIPTION
## General information
Replaces EMAGed recycler gibbing with 100* slash damage.

\* See technical details section

## Why / Balance
Part of ongoing efforts to complicate round removal, on the road to axing Rule 9.

As established by #362 the game shouldn't let you effortlessly remove multiple players (nor should it ask you to, but that's a separate conversation for a future pull)
Magged recyclers are a cheap method of mass body disposal that traitors don't deserve, or need.
Their chief use is indiscriminate obliteration of the station, either intentionally or haphazardly.
In the least egregious cases a magged recycler deletes 1 to 5 players with no recourse on their part, before someone can notice and break the recycler.
In the most egregious cases a traitor can delete everyone on the station with a single 5 TC purchase and a wrench.

This keeps tampering with recyclers a tool to punish people falling for social engineering that the victims can counteract & recover from.

## Technical details
Adds a Damage field to MaterialReclaimerComponent.

Replaces the MaterialReclaimerSystem.Recycle() guaranteed gibbing logic with damage dealing.
Due to the caveat of this method relying on physics it runs _more than once_; the intended damage is 100 slash per recycle, I couldn't get it to trigger more than once on humanoids, so I opted for 50 slash in the specifier, mice thrown at the recycler sometimes take 150 to 250 damage for inscrutable reasons.

A possible randomness edgecase was deemed an acceptable compromise for removing possibly the dumbest interaction in the whole game.

## Test plan
Load up a map with a recycler. Emag it. Walk into it. Live.

## Media
<img width="898" height="535" alt="tmp" src="https://github.com/user-attachments/assets/2ad54aa8-b853-4e87-9a4e-dbdd2ae7381f" />

## Breaking changes
N/A

## Changelog
:cl:
- tweak: EMAGed recyclers now deal 100 Slash damage, abated by armor - instead of gibbing people.