### PR TITLE
Improve round restart vote logic

### DIFF
--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -79,6 +79,9 @@ namespace Content.Server.Voting.Managers
 
         private void CreateRestartVote(ICommonSession? initiator)
         {
+            StartVote(initiator);
+            /* // Carpmosia-start - Better restarts
+            // nobody needs all this shit
 
             var playerVoteMaximum = _cfg.GetCVar(CCVars.VoteRestartMaxPlayers);
             var totalPlayers = _playerManager.Sessions.Count(session => session.Status != SessionStatus.Disconnected);
@@ -94,6 +97,7 @@ namespace Content.Server.Voting.Managers
             {
                 NotifyNotEnoughGhostPlayers(ghostVotePercentageRequirement, ghostVoterPercentage);
             }
+            */ // Carpmosia-end - Better restarts
         }
 
         /// <summary>
@@ -146,7 +150,7 @@ namespace Content.Server.Voting.Managers
                 {
                     (Loc.GetString("ui-vote-restart-yes"), "yes"),
                     (Loc.GetString("ui-vote-restart-no"), "no"),
-                    (Loc.GetString("ui-vote-restart-abstain"), "abstain")
+                //  (Loc.GetString("ui-vote-restart-abstain"), "abstain") // Carpmosia-edit - Better restarts
                 },
                 Duration = alone
                     ? TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerAlone))
@@ -169,20 +173,12 @@ namespace Content.Server.Voting.Managers
 
                 var ratioRequired = _cfg.GetCVar(CCVars.VoteRestartRequiredRatio);
                 if (total > 0 && votesYes / (float) total >= ratioRequired)
-                {
-                    // Check if an admin is online, and ignore the passed vote if the cvar is enabled
-                    if (_cfg.GetCVar(CCVars.VoteRestartNotAllowedWhenAdminOnline) && _adminMgr.ActiveAdmins.Count() != 0)
-                    {
-                        _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Restart vote attempted to pass, but an admin was online. {votesYes}/{votesNo}");
-                    }
-                    else // If the cvar is disabled or there's no admins on, proceed as normal
-                    {
-                        _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Restart vote succeeded: {votesYes}/{votesNo}");
-                        _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-restart-succeeded"));
-                        var roundEnd = _entityManager.EntitySysManager.GetEntitySystem<RoundEndSystem>();
-                        roundEnd.EndRound();
-                    }
-                }
+                { // Carpmosia-start - Better restarts
+                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Restart vote succeeded: {votesYes}/{votesNo}");
+                    _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-restart-succeeded"));
+                    var roundEnd = _entityManager.EntitySysManager.GetEntitySystem<RoundEndSystem>();
+                    roundEnd.EndRound();
+                } // Carpmosia-end - Better restarts
                 else
                 {
                     _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Restart vote failed: {votesYes}/{votesNo}");
@@ -201,8 +197,8 @@ namespace Content.Server.Voting.Managers
             {
                 if (player != initiator)
                 {
-                    // Everybody else defaults to an abstain vote to say they don't mind.
-                    vote.CastVote(player, 2);
+                    // Abstain logic is opaque and meaningless // Carpmosia-edit - Better restarts
+                    vote.CastVote(player, 1); // Carpmosia-edit - Better restarts
                 }
             }
         }

--- a/Resources/ConfigPresets/_Carpmosia/production.toml
+++ b/Resources/ConfigPresets/_Carpmosia/production.toml
@@ -23,3 +23,5 @@ replay.auto_record_name = "{year}_{month}/{year}_{month}_{day}/{year}_{month}_{d
 server.uptime_restart_minutes = 1440
 server.lobby_name = "Carpmosia"
 
+# CCVars.Vote
+vote.restart_required_ratio = 0.75


### PR DESCRIPTION
By GUTTING it like a fish.
## General information
Simplifies round restart votes by 1) making them callable at any time 2) removing abstinence 3) removing admin presence logic.
Also knocks Yes vote threshold down to 75% down from 85% because I was asked to.

## Why / Balance
Necessary for future changes.

Vote abstinence logic is opaque and meaningless when Nay and Abs are functionally identical.
Rounds becoming unplayable don't _necessarily_ mean a server wipe, and existing logic includes skipping the ghost check below a certain population, making it further redundant.
The CCVar preventing restarts with online admins is _not telegraphed_ in chat - only in adminlogs - and I didn't even know it _existed_ before looking at the C# (no wonder everyone complains about the restart votes never working), and the functionality was deemed undesirable.

## Technical details
Comments out undesirable logic in `VoteManager.DefaultVotes` and adds one entry to the production config preset.

## Test plan
1) Launch as many game clients as you can without killing your computer.
2) `sudo cvar votes.timerrestart 10`
3) Run a bunch of restart votes and look at them.

## Media
Imagine it or something, I'm not launching more than 3 game clients to take a screenshot.

## Breaking changes
Several CCVars are now obsolete and unused and I'm not sure what to do with them.

## Changelog
:cl:
- tweak: You can no longer abstain from round restart votes.
- tweak: You can now call round restart votes at any time.
- tweak: Did you know that restart votes silently fail if an admin is present? Well, not anymore they don't.