### PR TITLE
Remove shuttle controls from comms consoles

### DIFF
--- a/Content.Client/Communications/UI/CommunicationsConsoleBoundUserInterface.cs
+++ b/Content.Client/Communications/UI/CommunicationsConsoleBoundUserInterface.cs
@@ -85,10 +85,10 @@ namespace Content.Client.Communications.UI
                 _menu.CurrentLevel = commsState.CurrentAlert;
                 _menu.CountdownEnd = commsState.ExpectedCountdownEnd;
 
-                _menu.UpdateCountdown();
+                // _menu.UpdateCountdown(); // Carpmosia-start - No recalls
                 _menu.UpdateAlertLevels(commsState.AlertLevels, _menu.CurrentLevel);
                 _menu.AlertLevelButton.Disabled = !_menu.AlertLevelSelectable;
-                _menu.EmergencyShuttleButton.Disabled = !_menu.CanCall;
+                // _menu.EmergencyShuttleButton.Disabled = !_menu.CanCall; // Carpmosia-start - No recalls
                 _menu.AnnounceButton.Disabled = !_menu.CanAnnounce;
                 _menu.BroadcastButton.Disabled = !_menu.CanBroadcast;
             }

--- a/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml
+++ b/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml
@@ -47,6 +47,7 @@
             </BoxContainer>
 
             <!-- EmergencyPart -->
+            <!-- Carpmosia-start - No recalls
             <BoxContainer Orientation="Vertical"
                 SeparationOverride="6">
 
@@ -57,6 +58,7 @@
                     Text="Placeholder Text"
                     ToolTip="{Loc 'comms-console-menu-emergency-shuttle-button-tooltip'}"/>
             </BoxContainer>
+            Carpmosia-end - No recalls -->
         </BoxContainer>
     </BoxContainer>
 </controls:FancyWindow>

--- a/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml.cs
+++ b/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml.cs
@@ -70,14 +70,14 @@ namespace Content.Client.Communications.UI
 
             AlertLevelButton.Disabled = !AlertLevelSelectable;
 
-            EmergencyShuttleButton.OnPressed += _ => OnEmergencyLevel?.Invoke();
-            EmergencyShuttleButton.Disabled = !CanCall;
+            // EmergencyShuttleButton.OnPressed += _ => OnEmergencyLevel?.Invoke(); // Carpmosia-edit - No recalls
+            // EmergencyShuttleButton.Disabled = !CanCall; // Carpmosia-edit - No recalls
         }
 
         protected override void FrameUpdate(FrameEventArgs args)
         {
             base.FrameUpdate(args);
-            UpdateCountdown();
+            // UpdateCountdown(); // Carpmosia-start - No recalls
         }
 
         // The current alert could make levels unselectable, so we need to ensure that the UI reacts properly.
@@ -117,6 +117,7 @@ namespace Content.Client.Communications.UI
             }
         }
 
+        /*  // Carpmosia-start - No recalls
         public void UpdateCountdown()
         {
             if (!CountdownStarted)
@@ -133,5 +134,6 @@ namespace Content.Client.Communications.UI
                 ("time", diff.ToString(@"hh\:mm\:ss", CultureInfo.CurrentCulture)));
             CountdownLabel.SetMessage(infoText);
         }
+        */ // Carpmosia-end - No recalls
     }
 }

--- a/Resources/Prototypes/IonLaws/IonLaw.yml
+++ b/Resources/Prototypes/IonLaws/IonLaw.yml
@@ -5,11 +5,13 @@
     food: 0.5
     RandomManifestFill: 0.15
 
-- type: ionLaw
-  id: CallShuttle
-  lawString: ion-storm-law-call-shuttle
-  selectorWeightAdjust:
-    RandomManifestFill: 0.15
+# Carpmosia-start - No recalls
+# type: ionLaw
+# id: CallShuttle
+# lawString: ion-storm-law-call-shuttle
+# selectorWeightAdjust:
+#   RandomManifestFill: 0.15
+# Carpmosia-end - No recalls
 
 - type: ionLaw
   id: CrewAre


### PR DESCRIPTION
## General information
Removes emergency shuttle control ( call / recall ) elements from the Communications Console UI.
Additionally removes the shuttle call Ion Law because it's completely inactionable now.

Requires #378 
(Not functionally, but it would help with the __EDGE CASES__ where the round should reasonably end before 90 minutes)

## Why / Balance
(assisted in writing by ringlespore & lady death's head)

1) **Rounds should not last two or three or more hours.**
You wanted to play for 3 to 5 hours straight? We have a thing for that, it's called playing multiple rounds in a row.
In this game's nature as a disaster simulator, you should _want_ to get out of dodge by at most 60 minutes into the round, and _have to_ by at most 90. If neither occur by 90 then _something with the game_ has gone amiss, and you DON'T wait another 90 minutes to see if anything "evac-worthy" happens, you Cycle Out so the next round hopefully works as intended.
There's no legitimate reason for a round to last more than 90 minutes; character interactions can pick up at the next round, Money-Making and Gas-Production and Some-Such should be done _in service to a real round_ and do not justify carrying on a dead one.
In case someone gets removed from the round they will be consigned to an Underwhelming observer experience, or an Underwhelming selection of ghostroles, delaying new presence in the round works in nobody's service.
That's all not to mention that playing a 5 hour round interrupted is Medically Inadvisable at the best of times.

2) **Early evacuation erodes gameplay quality.**
Haphazard use of shuttle calling ruins the element of Disaster Simulator. You are always one keystroke away from erasing the very possibility of an engaging round.
An early evacuation can rob antagonists of Their Shot at antagonism, completely deny NukeOps or Traitors or whathaveyou of Gameplay, that they may have been waiting for days or weeks to get an attempt at.
Removing early evacuations removes the incentive for Traitors to cause "evac-worthy" damage, being another step towards removing Excessive Destruction rules.
Evacuating early lets Security give up and wait for the shuttle instead of persisting and excising large threats.
Evacuating early lets Engineering give up and wait for the shuttle instead of pulling through and fixing severe hull damage or power failures.
Game went amiss and nobody can recover the station unreasonably early? We have a solution to that, it's called a restart vote - confer  #378

3) **Shuttle votes erode roleplay quality.**
The status quo among the Command playerbase at the moment are kneejerk (re)call votes via comms consoles - either to the automatic call or at the first sight of anything going wrong - in the realm of "Do we recall Y for recall N for stay on common radio". And nothing short of a mass ban wave or taking away the option can effectively abate it.
Shuttle votes of this kind are inherently LRP, not just how through they're typically done, but because they subvert the worldbuilding & intended gameplay in that Command has control and the crew has to listen to them.


## Technical details
Comments out UI elements and corresponding UI logic, does not touch system logic but that can be included if deemed necessary.
Comments out an ion law prototype.

## Test plan
1) Left click on a Communications console.
2) Rejoice.

## Media
Also included is the station AI intrinsic announcement UI, which couldn't be used for calling shuttles anyway.
<img width="1107" height="652" alt="tmp" src="https://github.com/user-attachments/assets/0febb5f6-5dea-477e-bd19-e37c451af270" />

## Breaking changes
N/A

## Changelog
:cl:
- remove: You can no longer manually Call or Recall the Emergency Shuttle. Rounds will last no more than 90 minutes, and less only under extreme duress.