### PR TITLE
Address some pain points with stripping items

### DIFF
--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -703,12 +703,7 @@ public abstract partial class SharedStrippableSystem : EntitySystem
     // Carpmosia-start - Stripping changes
     public bool IsRestrained(EntityUid target)
     {
-        if (TryComp<CuffableComponent>(target, out var cuffed) && cuffed.CuffedHandCount > 0)
-        {
-            return true;
-        }
-
-        return false;
+        return TryComp<CuffableComponent>(target, out var cuffed) && cuffed.CuffedHandCount > 0;
     }
     // Carpmosia-end - Stripping changes
 }

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -222,7 +222,7 @@ public abstract partial class SharedStrippableSystem : EntitySystem
             BreakOnDamage = true,
             BreakOnMove = true,
             NeedHand = true,
-            DuplicateCondition = DuplicateConditions.None // Carpmosia-edit - Slower stripping
+            DuplicateCondition = IsRestrained(target) ? DuplicateConditions.SameTool : DuplicateConditions.None // Carpmosia-edit - Stripping changes
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
@@ -326,7 +326,7 @@ public abstract partial class SharedStrippableSystem : EntitySystem
             BreakOnMove = true,
             NeedHand = true,
             BreakOnHandChange = false, // Allow simultaneously removing multiple items.
-            DuplicateCondition = DuplicateConditions.None // Carpmosia-edit - Slower stripping
+            DuplicateCondition = IsRestrained(target) ? DuplicateConditions.SameTool : DuplicateConditions.None // Carpmosia-edit - Stripping changes
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
@@ -429,7 +429,7 @@ public abstract partial class SharedStrippableSystem : EntitySystem
             BreakOnDamage = true,
             BreakOnMove = true,
             NeedHand = true,
-            DuplicateCondition = DuplicateConditions.None // Carpmosia-edit - Slower stripping
+            DuplicateCondition = IsRestrained(target) ? DuplicateConditions.SameTool : DuplicateConditions.None // Carpmosia-edit - Stripping changes
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
@@ -540,7 +540,7 @@ public abstract partial class SharedStrippableSystem : EntitySystem
             BreakOnMove = true,
             NeedHand = true,
             BreakOnHandChange = false, // Allow simultaneously removing multiple items.
-            DuplicateCondition = DuplicateConditions.None // Carpmosia-edit - Slower stripping
+            DuplicateCondition = IsRestrained(target) ? DuplicateConditions.SameTool : DuplicateConditions.None  // Carpmosia-edit - Stripping changes
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
@@ -699,4 +699,16 @@ public abstract partial class SharedStrippableSystem : EntitySystem
 
         return !HasComp<BypassInteractionChecksComponent>(viewer);
     }
+
+    // Carpmosia-start - Stripping changes
+    public bool IsRestrained(EntityUid target)
+    {
+        if (TryComp<CuffableComponent>(target, out var cuffed) && cuffed.CuffedHandCount > 0)
+        {
+            return true;
+        }
+
+        return false;
+    }
+    // Carpmosia-end - Stripping changes
 }

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -540,7 +540,7 @@ public abstract partial class SharedStrippableSystem : EntitySystem
             BreakOnMove = true,
             NeedHand = true,
             BreakOnHandChange = false, // Allow simultaneously removing multiple items.
-            DuplicateCondition = IsRestrained(target) ? DuplicateConditions.SameTool : DuplicateConditions.None  // Carpmosia-edit - Stripping changes
+            DuplicateCondition = IsRestrained(target) ? DuplicateConditions.SameTool : DuplicateConditions.None // Carpmosia-edit - Stripping changes
         };
 
         _doAfterSystem.TryStartDoAfter(doAfterArgs);

--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -24,7 +24,7 @@
   components:
   - type: Pacified
   - type: Thieving
-    stripTimeReduction: 2
+    stripTimeReduction: 2.5 # Carpmosia-edit - Stripping changes
     stealthy: true
   mindRoles:
   - MindRoleThief


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Follow up to https://github.com/carpmosia/carpmosia/pull/359.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Some early feedback has indicated that one of the pain points caused by our changes to stripping is security having to spend much more time brigging people. This change to stripping will allow you to strip people fully whilst they are in restraints without cancelling the doafter. 

Another less-intentional result of the change from 359 is that thief has received a nerf. I have decided to compensate them slightly by making them faster to strip people when pickpocketing. I want to make a further change to it to allow pickpocketing to be even faster as part of a slight rewrite to the stripping system, but that can come later.
## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->
Added a check to see if the target is restrained and dictate behavior of the doafter based on that.
## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Load into server, spawn urist, equip them fully, strip them with restraints and without.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- tweak: Someone in restraints can have multiple items stripped off their person at once again.
- tweak: Thieves can now strip people slightly faster when pickpocketing
