### PR TITLE
Less annoying bureaucratic error

### DIFF
--- a/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
+++ b/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
@@ -29,12 +29,20 @@ public sealed partial class BureaucraticErrorRule : StationEventSystem<Bureaucra
         if (jobList.Count == 0)
             return;
 
+        // Carpmosia-start - Less annoying bureaucratic error
+        var lower = (int) (jobList.Count * 0.20);
+        var upper = (int) (jobList.Count * 0.30);
+        // Changing every role is maybe a bit too chaotic so instead change 20-30% of them.
+        var num = RobustRandom.Next(lower, upper);
+
         // Low chance to completely change up the late-join landscape by closing all positions except infinite slots.
         // Lower chance than the /tg/ equivalent of this event.
         if (RobustRandom.Prob(0.25f))
         {
-            var chosenJob = RobustRandom.PickAndTake(jobList);
-            _stationJobs.MakeJobUnlimited(chosenStation.Value, chosenJob); // INFINITE chaos.
+            for (var i = 0; i < num; i++)
+            {
+                _stationJobs.MakeJobUnlimited(chosenStation.Value, RobustRandom.PickAndTake(jobList)); // INFINITE chaos.
+            }
             foreach (var job in jobList)
             {
                 if (_stationJobs.IsJobUnlimited(chosenStation.Value, job))
@@ -44,10 +52,7 @@ public sealed partial class BureaucraticErrorRule : StationEventSystem<Bureaucra
         }
         else
         {
-            var lower = (int) (jobList.Count * 0.20);
-            var upper = (int) (jobList.Count * 0.30);
-            // Changing every role is maybe a bit too chaotic so instead change 20-30% of them.
-            var num = RobustRandom.Next(lower, upper);
+        // Carpmosia-end - Less annoying bureaucratic error
             for (var i = 0; i < num; i++)
             {
                 var chosenJob = RobustRandom.PickAndTake(jobList);


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Bureaucratic has a fun little thing with 25% to nuke all roles but ONE (and passenger), while making that one infinite.
Adjusted it to instead make MORE roles infinite, while still nuking the rest. This should hopefully reduce the amount of job lockouts for late joiners, while keeping the absolute absurdity and fun of the rare event.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Make latejoin life better

## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->
- [x] Changed some Bureaucratic event logic 

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
`addgamerule BureaucraticError` several times until most jobs are locked out

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->
<img width="393" height="1106" alt="image" src="https://github.com/user-attachments/assets/402b6de3-9ea9-4ab3-bc65-ed6fdb2a09ba" />
<img width="393" height="529" alt="image" src="https://github.com/user-attachments/assets/430539a2-15d7-426d-bbe1-b0324b336c24" />

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->
None

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- tweak: BureaucraticError's extreme case of locking out every job has been tweaked to leave more (20-30%) of jobs unlocked
