### PR TITLE
Removed pet fish's ability to combat

### DIFF
--- a/Resources/Prototypes/_Carpmosia/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Mobs/NPCs/animals.yml
@@ -150,6 +150,8 @@
   - type: MovementSpeedModifier
     baseWalkSpeed : 0.65
     baseSprintSpeed : 1.0
+  - type: CombatMode
+    combatToggleAction: ActionCombatModeToggleOff
   - type: MobPrice
     price: 100
   - type: Extractable


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Oversight, pet fish were never intended to cause damage. They're tiny, they're fish and they're in a plastic bag!

## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->
- Added `CombatMode` component with `combatToggleAction: ActionCombatModeToggleOff` (like snails) to `MobBagFish`.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
- Control fish mob, see that it is no longer able to toggle combat mode.

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- tweak: Pet fish can no longer bite things
