### PR TITLE
Added player_status_count metric

### DIFF
--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -97,6 +97,9 @@ namespace Content.Server.GameTicking
                 "Overflow role does not have the correct name!");
             InitializeGameRules();
             InitializeReplays();
+
+            InitializeMetrics(); // Carpmosia-edit - Extra prometheus metrics
+
             _initialized = true;
         }
 

--- a/Content.Server/_Carpmosia/GameTicking/GameTicker.Metrics.cs
+++ b/Content.Server/_Carpmosia/GameTicking/GameTicker.Metrics.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Shared.GameTicking;
 using Robust.Server.DataMetrics;
 using System.Diagnostics.Metrics;
+using System.Diagnostics;
 
 namespace Content.Server.GameTicking;
 
@@ -12,6 +13,7 @@ public sealed partial class GameTicker
 
     private Dictionary<PlayerGameStatus, int>? _playerStatusCounts;
 
+    [Conditional("RELEASE")]
     private void InitializeMetrics()
     {
         _metrics.UpdateMetrics += MetricsOnUpdateMetrics;

--- a/Content.Server/_Carpmosia/GameTicking/GameTicker.Metrics.cs
+++ b/Content.Server/_Carpmosia/GameTicking/GameTicker.Metrics.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using Content.Shared.GameTicking;
+using Robust.Server.DataMetrics;
+using System.Diagnostics.Metrics;
+
+namespace Content.Server.GameTicking;
+
+public sealed partial class GameTicker
+{
+    [Dependency] private IMetricsManager _metrics = default!;
+    [Dependency] private IMeterFactory _meterFactory = default!;
+
+    private Dictionary<PlayerGameStatus, int>? _playerStatusCounts;
+
+    private void InitializeMetrics()
+    {
+        _metrics.UpdateMetrics += MetricsOnUpdateMetrics;
+
+        var meter = _meterFactory.Create("SS14.GameTicker");
+
+        meter.CreateObservableGauge(
+            "player_status_count",
+            MeasureAdminCount,
+            null,
+            "The status of online players");
+    }
+
+    private void MetricsOnUpdateMetrics()
+    {
+        _sawmill.Verbose("Updating metrics");
+
+        var dict = new Dictionary<PlayerGameStatus, int>();
+
+        foreach (var status in Enum.GetValues<PlayerGameStatus>())
+        {
+            dict.Add(status, _playerGameStatuses.Values.Count(x => x == status));
+        }
+
+        _playerStatusCounts = dict;
+    }
+
+    private IEnumerable<Measurement<int>> MeasureAdminCount()
+    {
+        if (_playerStatusCounts == null)
+            yield break;
+
+        foreach (var (status, count) in _playerStatusCounts)
+        {
+            yield return new Measurement<int>(
+                count,
+                new KeyValuePair<string, object?>("status", status.ToString()));
+        }
+    }
+}
+


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Added a player_status_count Prometheus metrics to count how many readied up players we have!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Metrics are good. Especially ready up metrics. Very good. Very useful.

## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->
- [x] Added `player_status_count` metric to count players in lobby, readied up, and in game

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
set `> cvar metrics.enabled True` on your test server and then check http://localhost:44880/metrics

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->
No

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->
No

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
No player facing changes
