### PR TITLE
Added empty medical belts to NanoMed Plus vends

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -31,12 +31,14 @@
 - type: vendingMachineInventory
   id: NanoMedPlusInventory
   startingInventory:
+    # Medical Essential Gear
+    #ClothingBeltMedicalFilled: 2 # Carpmosia-edit - Dingus bags
     # Shared Essential
     HandheldHealthAnalyzer: 3
     JetInjector: 3
-    # Medical Essential Gear
     ClothingBeltMedical: 2 # Carpmosia-edit - Dingus bags
     # Paramed Essential Gear
+    #ClothingBeltMedicalEMTFilled: 1 # Carpmosia-edit - Dingus bags
     EmergencyRollerBedSpawnFolded: 1
     BoxBodyBag: 1
     # Extra Expendable Gear

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -31,8 +31,6 @@
 - type: vendingMachineInventory
   id: NanoMedPlusInventory
   startingInventory:
-    # Medical Essential Gear
-    #ClothingBeltMedicalFilled: 2 # Carpmosia-edit - Dingus bags
     # Shared Essential
     HandheldHealthAnalyzer: 3
     JetInjector: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -37,7 +37,11 @@
     HandheldHealthAnalyzer: 3
     JetInjector: 3
     # Paramed Essential Gear
-    #ClothingBeltMedicalEMTFilled: 1 # Carpmosia-edit - Dingus bags
+# Shared Essential
+HandheldHealthAnalyzer: 3
+JetInjector: 3
+# Paramed Essential Gear
+ClothingBeltMedical: 2 # Carpmosia-edit - Dingus bags
     EmergencyRollerBedSpawnFolded: 1
     BoxBodyBag: 1
     # Extra Expendable Gear

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -31,17 +31,12 @@
 - type: vendingMachineInventory
   id: NanoMedPlusInventory
   startingInventory:
-    # Medical Essential Gear
-    ClothingBeltMedical: 2 # Carpmosia-edit - Dingus bags
     # Shared Essential
     HandheldHealthAnalyzer: 3
     JetInjector: 3
+    # Medical Essential Gear
+    ClothingBeltMedical: 2 # Carpmosia-edit - Dingus bags
     # Paramed Essential Gear
-# Shared Essential
-HandheldHealthAnalyzer: 3
-JetInjector: 3
-# Paramed Essential Gear
-ClothingBeltMedical: 2 # Carpmosia-edit - Dingus bags
     EmergencyRollerBedSpawnFolded: 1
     BoxBodyBag: 1
     # Extra Expendable Gear

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -31,6 +31,8 @@
 - type: vendingMachineInventory
   id: NanoMedPlusInventory
   startingInventory:
+    # Medical Essential Gear
+    ClothingBeltMedical: 2 # Carpmosia-edit - Empty medical belts due to bottle content moved to fluid bags
     # Shared Essential
     HandheldHealthAnalyzer: 3
     JetInjector: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -32,7 +32,7 @@
   id: NanoMedPlusInventory
   startingInventory:
     # Medical Essential Gear
-    ClothingBeltMedical: 2 # Carpmosia-edit - Empty medical belts due to bottle content moved to fluid bags
+    ClothingBeltMedical: 2 # Carpmosia-edit - Dingus bags
     # Shared Essential
     HandheldHealthAnalyzer: 3
     JetInjector: 3


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Medical belts were removed from medvends in the PR adding fluid bags (#319).  
This is a problem since it is possible to run out of belts for medics on maps without a sufficient amount of lockers.  

## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->
Added `ClothingBeltMedical: 2` to `NanoMedPlusInventory` catalog.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Go to any map and check that MedVendPlus has two empty medbelts in it.

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- tweak: Added two empty medical belts to the NanoMed Plus inventory.
