### PR TITLE
Fix mislabeled traumox beaker

### DIFF
--- a/Resources/Prototypes/_Carpmosia/Entities/Objects/Specific/Chemistry/chemistry.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Objects/Specific/Chemistry/chemistry.yml
@@ -4,7 +4,7 @@
   suffix: traumoxadone
   components:
   - type: Label
-    currentLabel: reagent-name-cryoxadone
+    currentLabel: reagent-name-traumoxadone
   - type: Solution
     solution:
       reagents:


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Fixes the traumoxadone beaker being mislabeled as cryoxadone.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Woops.
## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- tweak: The Traumoxadone beakers at Centcomm now have the correct label.

