### PR TITLE
Adds Nukeops Arrival Announcement

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -106,7 +106,7 @@ public sealed partial class NukeopsRuleComponent : Component
     /// Whether the arrival alert has played.
     /// </summary>
     [DataField]
-    public bool ArrivalAnnounced = false;
+    public bool ArrivalAnnounced;
 
     /// <summary>
     /// Alert levels that are 'below' red, used for changing it to red on FTL end

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -100,6 +100,11 @@ public sealed partial class NukeopsRuleComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier GreetSoundNotification = new SoundPathSpecifier("/Audio/Ambience/Antag/nukeops_start.ogg");
+
+    // Carpmosia-start - Nukeops Arrival Message
+    [DataField]
+    public bool ArrivalAnnounced = false;
+    // Carpmosia-end - Nukeops Arrival Message
 }
 
 public enum WinType : byte

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -102,8 +102,17 @@ public sealed partial class NukeopsRuleComponent : Component
     public SoundSpecifier GreetSoundNotification = new SoundPathSpecifier("/Audio/Ambience/Antag/nukeops_start.ogg");
 
     // Carpmosia-start - Nukeops Arrival Message
+    /// <summary>
+    /// Whether the arrival alert has played.
+    /// </summary>
     [DataField]
     public bool ArrivalAnnounced = false;
+
+    /// <summary>
+    /// Alert levels that are 'below' red, used for changing it to red on FTL end
+    /// </summary>
+    [DataField]
+    public HashSet<string> Alerts = new HashSet<string>() { "green", "blue", "yellow", "violet" };
     // Carpmosia-end - Nukeops Arrival Message
 }
 

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -45,7 +45,6 @@ using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using System.Data;
 using System.Linq;
-using System.Reflection.Emit; // Carpmosia-edit - Nukeops Arrival Message
 using System.Text;
 
 namespace Content.Server.GameTicking.Rules;

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -452,13 +452,29 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
                 continue;
             if (!TryGetRandomStation(out var chosenStation))
                 return;
+            // Don't announce multiple times
+            if (nukeops.ArrivalAnnounced == true )
+                continue;
 
+            MapId? targetStationMap = null;
+            if (nukeops.TargetStation != null && TryComp(nukeops.TargetStation, out StationDataComponent? data))
+            {
+                var grid = data.Grids.FirstOrNull();
+                targetStationMap = grid != null
+                    ? Transform(grid.Value).MapID
+                    : null;
+            }
+            // Don't announce if we aren't going to the right place
+            if (targetStationMap == null || targetStationMap != Transform(ev.MapUid).MapID)
+                continue;
+            // Only set the alert level if its not already red
             if (_alertLevelSystem.GetLevel(chosenStation.Value) != "red")
-                _alertLevelSystem.SetLevel(chosenStation.Value, "red", true, true, true);
+                _alertLevelSystem.SetLevel(chosenStation.Value, "red", false, false, true);
 
             var msg = Loc.GetString("nukeops-shuttle-warning");
             _chat.DispatchGlobalAnnouncement(msg, playSound: false, colorOverride: Color.Red);
             _audio.PlayGlobal("/Audio/Misc/notice1.ogg", Filter.Broadcast(), true);
+            nukeops.ArrivalAnnounced = true;
         }
     }
     // Carpmosia-end - Nukeops Arrival Message

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -35,6 +35,7 @@ using Content.Shared.Store.Components;
 using Content.Shared.Tag;
 using Content.Shared.Zombies;
 using Robust.Server.Player;
+using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems; // Carpmosia-edit - Nukeops Arrival Message
 using Robust.Shared.Containers;
 using Robust.Shared.Map;

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -467,8 +467,10 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
             // Don't announce if we aren't going to the right place
             if (targetStationMap == null || targetStationMap != Transform(ev.MapUid).MapID)
                 continue;
-            // Only set the alert level if its not already red
-            if (_alertLevelSystem.GetLevel(chosenStation.Value) != "red")
+                
+            // Only set the alert level if its not already red or higher
+            var alert = _alertLevelSystem.GetLevel(chosenStation.Value);
+            if (alert != "red" || alert != "gamma" || alert != "delta" || alert != "epsilon")
                 _alertLevelSystem.SetLevel(chosenStation.Value, "red", false, false, true);
 
             var msg = Loc.GetString("nukeops-shuttle-warning");

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -454,7 +454,7 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
             if (!TryGetRandomStation(out var chosenStation))
                 return;
 
-            if (!_alertLevelSystem.GetLevel(chosenStation.Value) == "red")
+            if (_alertLevelSystem.GetLevel(chosenStation.Value) != "red")
                 _alertLevelSystem.SetLevel(chosenStation.Value, "red", true, true, true);
 
             var msg = Loc.GetString("nukeops-shuttle-warning");

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -453,10 +453,10 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
                 continue;
             if (!TryGetRandomStation(out var chosenStation))
                 return;
-            if (_alertLevelSystem.GetLevel(chosenStation.Value) == "red")
-                return;
 
-            _alertLevelSystem.SetLevel(chosenStation.Value, "red", true, true, true);
+            if (!_alertLevelSystem.GetLevel(chosenStation.Value) == "red")
+                _alertLevelSystem.SetLevel(chosenStation.Value, "red", true, true, true);
+
             var msg = Loc.GetString("nukeops-shuttle-warning");
             _chat.DispatchGlobalAnnouncement(msg, playSound: false, colorOverride: Color.Red);
             _audio.PlayGlobal("/Audio/Misc/notice1.ogg", Filter.Broadcast(), true);

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -467,10 +467,10 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
             // Don't announce if we aren't going to the right place
             if (targetStationMap == null || targetStationMap != Transform(ev.MapUid).MapID)
                 continue;
-                
+
             // Only set the alert level if its not already red or higher
             var alert = _alertLevelSystem.GetLevel(chosenStation.Value);
-            if (alert != "red" || alert != "gamma" || alert != "delta" || alert != "epsilon")
+            if (nukeops.Alerts.Contains(alert))
                 _alertLevelSystem.SetLevel(chosenStation.Value, "red", false, false, true);
 
             var msg = Loc.GetString("nukeops-shuttle-warning");

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -453,7 +453,7 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
             if (!TryGetRandomStation(out var chosenStation))
                 return;
             // Don't announce multiple times
-            if (nukeops.ArrivalAnnounced == true )
+            if (nukeops.ArrivalAnnounced)
                 continue;
 
             MapId? targetStationMap = null;

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -35,7 +35,7 @@ using Content.Shared.Store.Components;
 using Content.Shared.Tag;
 using Content.Shared.Zombies;
 using Robust.Server.Player;
-using Robust.Shared.Audio;
+using Robust.Shared.Audio; // Carpmosia-edit - Nukeops Arrival Message
 using Robust.Shared.Audio.Systems; // Carpmosia-edit - Nukeops Arrival Message
 using Robust.Shared.Containers;
 using Robust.Shared.Map;

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -475,7 +475,7 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
 
             var msg = Loc.GetString("nukeops-shuttle-warning");
             _chat.DispatchGlobalAnnouncement(msg, playSound: false, colorOverride: Color.Red);
-            _audio.PlayGlobal("/Audio/Misc/notice1.ogg", Filter.Broadcast(), true);
+            _audio.PlayGlobal(new SoundPathSpecifier("/Audio/Misc/notice1.ogg"), Filter.Broadcast(), true);
             nukeops.ArrivalAnnounced = true;
         }
     }

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -1,4 +1,6 @@
+using Content.Server.AlertLevel; // Carpmosia-edit - Nukeops Arrival Message
 using Content.Server.Antag;
+using Content.Server.Chat.Systems; // Carpmosia-edit - Nukeops Arrival Message
 using Content.Server.Communications;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Nuke;
@@ -33,21 +35,26 @@ using Content.Shared.Store.Components;
 using Content.Shared.Tag;
 using Content.Shared.Zombies;
 using Robust.Server.Player;
+using Robust.Shared.Audio.Systems; // Carpmosia-edit - Nukeops Arrival Message
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
+using Robust.Shared.Player; // Carpmosia-edit - Nukeops Arrival Message
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using System.Data;
 using System.Linq;
+using System.Reflection.Emit; // Carpmosia-edit - Nukeops Arrival Message
 using System.Text;
 
 namespace Content.Server.GameTicking.Rules;
 
 public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
 {
+    [Dependency] private AlertLevelSystem _alertLevelSystem = default!; // Carpmosia-edit - Nukeops Arrival Message
     [Dependency] private AntagSelectionSystem _antag = default!;
+    [Dependency] private ChatSystem _chat = default!; // Carpmosia-edit - Nukeops Arrival Message
     [Dependency] private EmergencyShuttleSystem _emergency = default!;
     [Dependency] private SharedIdCardSystem _idCard = default!;
     [Dependency] private SharedJobSystem _jobs = default!;
@@ -57,6 +64,7 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
     [Dependency] private NpcFactionSystem _npcFaction = default!;
     [Dependency] private PopupSystem _popupSystem = default!;
     [Dependency] private RoundEndSystem _roundEndSystem = default!;
+    [Dependency] private SharedAudioSystem _audio = default!; // Carpmosia-edit - Nukeops Arrival Message
     [Dependency] private SharedContainerSystem _containers = default!;
     [Dependency] private SharedRoleSystem _roles = default!;
     [Dependency] private SharedStationSystem _station = default!;
@@ -89,6 +97,7 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
         SubscribeLocalEvent<NukeopsRoleComponent, GetBriefingEvent>(OnGetBriefing);
 
         SubscribeLocalEvent<ConsoleFTLAttemptEvent>(OnShuttleFTLAttempt);
+        SubscribeLocalEvent<FTLCompletedEvent>(OnShuttleFTLCompleted); // Carpmosia-edit - Nukeops Arrival Message
         SubscribeLocalEvent<WarDeclaredEvent>(OnWarDeclared);
         SubscribeLocalEvent<CommunicationConsoleCallShuttleAttemptEvent>(OnShuttleCallAttempt);
 
@@ -433,6 +442,27 @@ public sealed partial class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleCompon
             }
         }
     }
+
+    // Carpmosia-start - Nukeops Arrival Message
+    private void OnShuttleFTLCompleted(ref FTLCompletedEvent ev)
+    {
+        var query = QueryActiveRules();
+        while (query.MoveNext(out var uid, out _, out var nukeops, out _))
+        {
+            if (ev.Entity != GetShuttle((uid, nukeops)))
+                continue;
+            if (!TryGetRandomStation(out var chosenStation))
+                return;
+            if (_alertLevelSystem.GetLevel(chosenStation.Value) == "red")
+                return;
+
+            _alertLevelSystem.SetLevel(chosenStation.Value, "red", true, true, true);
+            var msg = Loc.GetString("nukeops-shuttle-warning");
+            _chat.DispatchGlobalAnnouncement(msg, playSound: false, colorOverride: Color.Red);
+            _audio.PlayGlobal("/Audio/Misc/notice1.ogg", Filter.Broadcast(), true);
+        }
+    }
+    // Carpmosia-end - Nukeops Arrival Message
 
     private void OnWarDeclared(ref WarDeclaredEvent ev)
     {

--- a/Resources/Locale/en-US/_Carpmosia/nukeops/shuttle.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/nukeops/shuttle.ftl
@@ -1,1 +1,1 @@
-nukeops-shuttle-warning = Warning! An FTL signature belonging to a Syndicate vessel was detected in your sector! Consider all personnel on board to be armed and dangerous.
+nukeops-shuttle-warning = Warning! A Syndicate FTL signature has been detected in your sector! Consider all personnel on board to be armed and dangerous.

--- a/Resources/Locale/en-US/_Carpmosia/nukeops/shuttle.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/nukeops/shuttle.ftl
@@ -1,0 +1,1 @@
+nukeops-shuttle-warning = Warning! An FTL signature belonging to a Syndicate vessel was detected in your sector! Consider all personnel on board to be armed and dangerous.


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Adds a special announcement when the nukie's shuttle FTLs into the sector on nukeops.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
After removal of the cargo weapon crates, its become a commonly executed strategy to try to seize control of the armory before the crew has a chance to properly respond, usually as early into the round as possible. If successful, this would leave the operative team in a very strong position to win with very little resistance. While we do want to reward the execution of a plan, and there does come a point that the crew should probably just lose, I feel like most nukie rounds are more entertaining when both sides of the conflict get to participate fully. Seizing armory before the crew can arm is a strategy intended to very specifically stop the crew from being able to participate, and tends to be a strategy that plays out in pretty boring ways. So, as a consequence, the crew are now alerted when operative's shuttle first FTLs to the system. One unfortunate casualty of this change is stealth-ops, but I believe between this change and bringing the full armory crate category back, I would rather have this change.
## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Spawn nukeops, either by forcing the preset or addgameruling nukeops. Go to shuttle. FTL to station. The announcement plays and the station is now in red alert.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- add: For nukeops, there is now an announcement that plays when the nukie shuttle first FTLs into the sector! This does not apply to Loneops.
