### PR TITLE
PDAs lock their uplinks on drop or being stripped

### DIFF
--- a/Content.Server/PDA/PdaSystem.cs
+++ b/Content.Server/PDA/PdaSystem.cs
@@ -65,7 +65,7 @@ namespace Content.Server.PDA
             SubscribeLocalEvent<PdaComponent, InventoryRelayedEvent<ChameleonControllerOutfitSelectedEvent>>(OnRelayedEventToIdCard);
             SubscribeLocalEvent<PdaComponent, InventoryRelayedEvent<VoiceMaskNameUpdatedEvent>>(OnRelayedEventToIdCard);
 
-            SubscribeLocalEvent<PdaComponent, DroppedEvent>(OnDrop); // Carpmosia-edit - Uplink Auto-locker
+            SubscribeLocalEvent<RingerUplinkComponent, DroppedEvent>(OnDrop); // Carpmosia-edit - Uplink Auto-locker
         }
 
         private void OnRelayedEventToIdCard<T>(Entity<PdaComponent> ent, ref InventoryRelayedEvent<T> args)
@@ -309,13 +309,10 @@ namespace Content.Server.PDA
         }
 
         // Carpmosia-start - Uplink Auto-locker
-        private void OnDrop(Entity<PdaComponent> ent, ref DroppedEvent args)
+        private void OnDrop(Entity<RingerUplinkComponent> ent, ref DroppedEvent args)
         {
-            if (!TryComp<RingerUplinkComponent>(ent, out var uplink))
-                return;
-
-            if (uplink!= null && uplink.Unlocked)
-                _ringer.LockUplink((ent.Owner, uplink));
+            _ringer.LockUplink(ent.Owner);
+            UpdatePdaUi(ent);
         }
         // Carpmosia-end - Uplink Auto-locker
 

--- a/Content.Server/PDA/PdaSystem.cs
+++ b/Content.Server/PDA/PdaSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.CartridgeLoader;
 using Content.Shared.Chat;
 using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.Implants;
+using Content.Shared.Interaction.Events; // Carpmosia-edit - Uplink Auto-locker
 using Content.Shared.Inventory;
 using Content.Shared.Light;
 using Content.Shared.Light.EntitySystems;
@@ -63,6 +64,8 @@ namespace Content.Server.PDA
             SubscribeLocalEvent<AlertLevelChangedEvent>(OnAlertLevelChanged);
             SubscribeLocalEvent<PdaComponent, InventoryRelayedEvent<ChameleonControllerOutfitSelectedEvent>>(OnRelayedEventToIdCard);
             SubscribeLocalEvent<PdaComponent, InventoryRelayedEvent<VoiceMaskNameUpdatedEvent>>(OnRelayedEventToIdCard);
+
+            SubscribeLocalEvent<PdaComponent, DroppedEvent>(OnDrop); // Carpmosia-edit - Uplink Auto-locker
         }
 
         private void OnRelayedEventToIdCard<T>(Entity<PdaComponent> ent, ref InventoryRelayedEvent<T> args)
@@ -304,6 +307,17 @@ namespace Content.Server.PDA
                 UpdatePdaUi(uid, pda);
             }
         }
+
+        // Carpmosia-start - Uplink Auto-locker
+        private void OnDrop(Entity<PdaComponent> ent, ref DroppedEvent args)
+        {
+            if (!TryComp<RingerUplinkComponent>(ent, out var uplink))
+                return;
+
+            if (uplink!= null && uplink.Unlocked)
+                _ringer.LockUplink((ent.Owner, uplink));
+        }
+        // Carpmosia-end - Uplink Auto-locker
 
         /// <summary>
         /// Returns the currently unlocked store, if there is one.

--- a/Content.Server/PDA/PdaSystem.cs
+++ b/Content.Server/PDA/PdaSystem.cs
@@ -311,7 +311,9 @@ namespace Content.Server.PDA
         // Carpmosia-start - Uplink Auto-locker
         private void OnDrop(Entity<RingerUplinkComponent> ent, ref DroppedEvent args)
         {
-            _ringer.LockUplink(ent.Owner);
+            if (TryComp<RemoteStoreComponent>(ent, out var remoteStore))
+                remoteStore.Store = null;
+            _ringer.LockUplink(ent!);
             UpdatePdaUi(ent);
         }
         // Carpmosia-end - Uplink Auto-locker


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Open uplinks will now automatically lock if they are stripped or otherwise dropped by their current holder.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Kills metagaming and complaints around PDA checking. Now you only need to do a PDA search for programs or funny ID cards. Traitors can still willingly give their uplink code to someone if they really want (and they can use it on their own PDA if they choose, given that uplinks are no longer tied to specific PDAs).
## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Make character a traitor, open uplink, drop/strip/throw PDA, the uplink is now closed.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- tweak: Open Traitor Uplinks now lock when their PDA is stripped or dropped.

