### PR TITLE
feat: 🐖💨Whoopie cushion furniture upgrades

### DIFF
--- a/Resources/Locale/en-US/_Carpmosia/recipes/tags.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/recipes/tags.ftl
@@ -1,3 +1,5 @@
+# clown
+construction-graph-tag-whoopie-cushion = a whoopie cushion
 # glasses
 construction-graph-tag-meson = engineering goggles
 construction-graph-tag-diag = diagnostic hud

--- a/Resources/Prototypes/Entities/Objects/Fun/sound_maker.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/sound_maker.yml
@@ -417,6 +417,7 @@
   - type: Tag
     tags:
     - Payload
+    - WhoopieCushion #Carpmosia-edit - whoopie furniture
   - type: EmitSoundOnUse
     sound: &SoundParp
       collection: Parp

--- a/Resources/Prototypes/Entities/Objects/Fun/sound_maker.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/sound_maker.yml
@@ -417,7 +417,7 @@
   - type: Tag
     tags:
     - Payload
-    - WhoopieCushion #Carpmosia-edit - whoopie furniture
+    - WhoopieCushion # Carpmosia-edit - whoopie furniture
   - type: EmitSoundOnUse
     sound: &SoundParp
       collection: Parp

--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -58,7 +58,6 @@
   - type: Anchorable
   - type: Pullable
 
-
 - type: entity
   parent: Bed
   id: MedicalBed
@@ -123,6 +122,11 @@
     state: mattress
   - type: Damageable
     damageModifierSet: Inflatable
+  #carpmosia-start - Whoopie Furniture, needed to upgrade into whoopie version
+  - type: Construction
+    graph: bed
+    node: mattress
+  #carpmosia-end - Whoopie Furniture
 
 - type: entity
   parent: Bed
@@ -180,3 +184,8 @@
           MaterialWoodPlank:
             min: 2
             max: 2
+  #carpmosia-start - Whoopie Furniture, needed to upgrade into whoopie version
+  - type: Construction
+    graph: bed
+    node: psychbed
+  #carpmosia-end - Whoopie Furniture

--- a/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/beds.yml
@@ -58,6 +58,7 @@
   - type: Anchorable
   - type: Pullable
 
+
 - type: entity
   parent: Bed
   id: MedicalBed
@@ -122,11 +123,11 @@
     state: mattress
   - type: Damageable
     damageModifierSet: Inflatable
-  #carpmosia-start - Whoopie Furniture, needed to upgrade into whoopie version
+  # Carpmosia-start - Whoopie Furniture, needed to upgrade into whoopie version
   - type: Construction
     graph: bed
     node: mattress
-  #carpmosia-end - Whoopie Furniture
+  # Carpmosia-end - Whoopie Furniture
 
 - type: entity
   parent: Bed
@@ -184,8 +185,8 @@
           MaterialWoodPlank:
             min: 2
             max: 2
-  #carpmosia-start - Whoopie Furniture, needed to upgrade into whoopie version
+  # Carpmosia-start - Whoopie Furniture, needed to upgrade into whoopie version
   - type: Construction
     graph: bed
     node: psychbed
-  #carpmosia-end - Whoopie Furniture
+  # Carpmosia-end - Whoopie Furniture

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -112,11 +112,11 @@
   components:
   - type: Sprite
     state: chair-greyscale
-#carpmosia-start - Whoopie Furniture, needed to upgrade into whoopie version
+  # Carpmosia-start - Whoopie Furniture, needed to upgrade into whoopie version
   - type: Construction
     graph: Seat
     node: chairGreyscale
-#carpmosia-end - Whoopie Furniture
+  # Carpmosia-end - Whoopie Furniture
 
 - type: entity
   name: stool
@@ -440,8 +440,8 @@
   components:
   - type: Sprite
     state: xeno-chair
-#carpmosia-start - Whoopie Furniture, needed to upgrade into whoopie version
+  # Carpmosia-start - Whoopie Furniture, needed to upgrade into whoopie version
   - type: Construction
     graph: Seat
     node: chairXeno
-#carpmosia-end - Whoopie Furniture
+  # Carpmosia-end - Whoopie Furniture

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -112,6 +112,11 @@
   components:
   - type: Sprite
     state: chair-greyscale
+#carpmosia-start - Whoopie Furniture, needed to upgrade into whoopie version
+  - type: Construction
+    graph: Seat
+    node: chairGreyscale
+#carpmosia-end - Whoopie Furniture
 
 - type: entity
   name: stool
@@ -435,3 +440,8 @@
   components:
   - type: Sprite
     state: xeno-chair
+#carpmosia-start - Whoopie Furniture, needed to upgrade into whoopie version
+  - type: Construction
+    graph: Seat
+    node: chairXeno
+#carpmosia-end - Whoopie Furniture

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/bed.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/bed.yml
@@ -47,7 +47,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-              # Carpmosia-start - whoopie furniture
+        # Carpmosia-start - whoopie furniture
         - to: bedWhoopie
           steps:
           - tag: WhoopieCushion
@@ -67,7 +67,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-# Carpmosia-end -whoopie furniture
+        # Carpmosia-end -whoopie furniture
 
     - node: dogbed
       entity: DogBed
@@ -80,7 +80,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-              # Carpmosia-start - whoopie furniture
+        # Carpmosia-start - whoopie furniture
         - to: dogbedWhoopie
           steps:
           - tag: WhoopieCushion
@@ -100,7 +100,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-# Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
 
     - node: medicalbed
       entity: MedicalBed
@@ -116,7 +116,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-              # Carpmosia-start - whoopie furniture
+        # Carpmosia-start - whoopie furniture
         - to: medicalbedWhoopie
           steps:
           - tag: WhoopieCushion
@@ -182,4 +182,4 @@
           steps:
             - tool: Prying
               doAfter: 1
- # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/bed.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/bed.yml
@@ -47,6 +47,28 @@
           steps:
             - tool: Screwing
               doAfter: 1
+              # Carpmosia-start - whoopie furniture
+        - to: bedWhoopie
+          steps:
+          - tag: WhoopieCushion
+            name: construction-graph-tag-whoopie-cushion
+            icon:
+              sprite: Objects/Fun/whoopie.rsi
+              state: icon
+            doAfter: 1
+
+    - node: bedWhoopie
+      entity: WhoopieBed
+      edges:
+        - to: bed
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+# Carpmosia-end -whoopie furniture
+
     - node: dogbed
       entity: DogBed
       edges:
@@ -58,6 +80,28 @@
           steps:
             - tool: Screwing
               doAfter: 1
+              # Carpmosia-start - whoopie furniture
+        - to: dogbedWhoopie
+          steps:
+          - tag: WhoopieCushion
+            name: construction-graph-tag-whoopie-cushion
+            icon:
+              sprite: Objects/Fun/whoopie.rsi
+              state: icon
+            doAfter: 1
+
+    - node: dogbedWhoopie
+      entity: WhoopieDogBed
+      edges:
+        - to: dogbed
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+# Carpmosia-end - whoopie furniture
+
     - node: medicalbed
       entity: MedicalBed
       edges:
@@ -72,3 +116,70 @@
           steps:
             - tool: Screwing
               doAfter: 1
+              # Carpmosia-start - whoopie furniture
+        - to: medicalbedWhoopie
+          steps:
+          - tag: WhoopieCushion
+            name: construction-graph-tag-whoopie-cushion
+            icon:
+              sprite: Objects/Fun/whoopie.rsi
+              state: icon
+            doAfter: 1
+
+    - node: medicalbedWhoopie
+      entity: WhoopieMedicalBed
+      edges:
+        - to: medicalbed
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+
+    - node: psychbed
+      entity: PsychBed
+      edges:
+        - to: psychbedWhoopie
+          steps:
+          - tag: WhoopieCushion
+            name: construction-graph-tag-whoopie-cushion
+            icon:
+              sprite: Objects/Fun/whoopie.rsi
+              state: icon
+            doAfter: 1
+
+    - node: psychbedWhoopie
+      entity: WhoopiePsychBed
+      edges:
+        - to: psychbed
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+
+    - node: mattress
+      entity: Mattress
+      edges:
+        - to: mattressWhoopie
+          steps:
+          - tag: WhoopieCushion
+            name: construction-graph-tag-whoopie-cushion
+            icon:
+              sprite: Objects/Fun/whoopie.rsi
+              state: icon
+            doAfter: 1
+
+    - node: mattressWhoopie
+      entity: WhoopieMattress
+      edges:
+        - to: mattress
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+ # Carpmosia-end - whoopie furniture

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/bed.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/bed.yml
@@ -47,7 +47,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: bedWhoopie
           steps:
           - tag: WhoopieCushion
@@ -67,7 +67,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end -whoopie furniture
+    # Carpmosia-end -whoopie furniture
 
     - node: dogbed
       entity: DogBed
@@ -80,7 +80,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: dogbedWhoopie
           steps:
           - tag: WhoopieCushion
@@ -100,7 +100,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
 
     - node: medicalbed
       entity: MedicalBed
@@ -116,7 +116,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: medicalbedWhoopie
           steps:
           - tag: WhoopieCushion
@@ -182,4 +182,4 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
@@ -103,6 +103,58 @@
           steps:
             - tool: Screwing
               doAfter: 1
+        # Carpmosia-start - whoopie furniture
+        - to: chairWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
+
+    - node: chairWhoopie
+      entity: WhoopieChair
+      edges:
+        - to: chair
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+
+    - node: chairGreyscale
+      entity: ChairGreyscale
+      edges:
+        - to: start
+          completed:
+            - !type:SpawnPrototype
+              prototype: SheetSteel1
+          steps:
+            - tool: Screwing
+              doAfter: 1
+        # Carpmosia-start - whoopie furniture
+        - to: chairGreyscaleWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
+
+    - node: chairGreyscaleWhoopie
+      entity: WhoopieChairGreyscale
+      edges:
+        - to: chairGreyscale
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+  # Carpmosia-end - whoopie furniture
 
     - node: stool
       entity: Stool
@@ -114,6 +166,27 @@
           steps:
             - tool: Screwing
               doAfter: 1
+        # Carpmosia-start - whoopie furniture
+        - to: stoolWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
+
+    - node: stoolWhoopie
+      entity: WhoopieStool
+      edges:
+        - to: stool
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+    # Carpmosia-end - whoopie furniture
 
     - node: stoolBar
       entity: StoolBar
@@ -125,6 +198,27 @@
           steps:
             - tool: Screwing
               doAfter: 1
+        # Carpmosia-start - whoopie furniture
+        - to: stoolBarWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
+
+    - node: stoolBarWhoopie
+      entity: WhoopieBarStool
+      edges:
+        - to: stoolBar
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+    # Carpmosia-end - whoopie furniture
 
     - node: chairBrass
       entity: ChairBrass
@@ -136,6 +230,27 @@
           steps:
             - tool: Screwing
               doAfter: 1
+        # Carpmosia-start - whoopie furniture
+        - to: chairBrassWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
+
+    - node: chairBrassWhoopie
+      entity: WhoopieChairBrass
+      edges:
+        - to: chairBrass
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+    # Carpmosia-end - whoopie furniture
 
     - node: chairOffice
       entity: ChairOfficeLight
@@ -148,7 +263,27 @@
           steps:
             - tool: Screwing
               doAfter: 1
+        # Carpmosia-start - whoopie furniture
+        - to: chairOfficeWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
 
+    - node: chairOfficeWhoopie
+      entity: WhoopieChairOfficeLight
+      edges:
+        - to: chairOffice
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+    # Carpmosia-end - whoopie furniture
     - node: chairOfficeDark
       entity: ChairOfficeDark
       edges:
@@ -160,7 +295,27 @@
           steps:
             - tool: Screwing
               doAfter: 1
+        # Carpmosia-start - whoopie furniture
+        - to: chairOfficeDarkWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
 
+    - node: chairOfficeDarkWhoopie
+      entity: WhoopieChairOfficeDark
+      edges:
+        - to: chairOfficeDark
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+    # Carpmosia-end - whoopie furniture
     - node: chairComfy
       entity: ComfyChair
       edges:
@@ -172,6 +327,27 @@
           steps:
             - tool: Screwing
               doAfter: 1
+        # Carpmosia-start - whoopie furniture
+        - to: chairComfyWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
+
+    - node: chairComfyWhoopie
+      entity: WhoopieComfyChair
+      edges:
+        - to: chairComfy
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+    # Carpmosia-end - whoopie furniture
 
     - node: chairPilotSeat
       entity: ChairPilotSeat
@@ -184,6 +360,27 @@
           steps:
             - tool: Screwing
               doAfter: 2
+        # Carpmosia-start - whoopie furniture
+        - to: chairPilotSeatWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
+
+    - node: chairPilotSeatWhoopie
+      entity: WhoopieChairPilotSeat
+      edges:
+        - to: chairPilotSeat
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+    # Carpmosia-end - whoopie furniture
 
     - node: chairWood
       entity: ChairWood
@@ -196,6 +393,27 @@
           steps:
             - tool: Screwing
               doAfter: 1
+        # Carpmosia-start - whoopie furniture
+        - to: chairWoodWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
+
+    - node: chairWoodWhoopie
+      entity: WhoopieChairWood
+      edges:
+        - to: chairWood
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+    # Carpmosia-end - whoopie furniture
 
     - node: chairMeat
       entity: ChairMeat
@@ -208,6 +426,27 @@
           steps:
             - tool: Screwing
               doAfter: 1
+        # Carpmosia-start - whoopie furniture
+        - to: chairMeatWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
+
+    - node: chairMeatWhoopie
+      entity: WhoopieChairMeat
+      edges:
+        - to: chairMeat
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+    # Carpmosia-end - whoopie furniture
 
     - node: chairFolding
       entity: ChairFolding
@@ -235,6 +474,27 @@
           steps:
             - tool: Screwing
               doAfter: 1
+        # Carpmosia-start - whoopie furniture
+        - to: chairSteelBenchWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
+
+    - node: chairSteelBenchWhoopie
+      entity: WhoopieSteelBench
+      edges:
+        - to: chairSteelBench
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+    # Carpmosia-end - whoopie furniture
 
     - node: stoolCard
       entity: CardStool
@@ -249,6 +509,27 @@
           steps:
             - tool: Slicing
               doAfter: 1
+        # Carpmosia-start - whoopie furniture
+        - to: stoolCardWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
+
+    - node: stoolCardWhoopie
+      entity: WhoopieCardStool
+      edges:
+        - to: stoolCard
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+    # Carpmosia-end - whoopie furniture
 
     - node: chairWoodBench
       entity: WoodenBench
@@ -261,6 +542,27 @@
           steps:
             - tool: Screwing
               doAfter: 2
+        # Carpmosia-start - whoopie furniture
+        - to: chairWoodBenchWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
+
+    - node: chairWoodBenchWhoopie
+      entity: WhoopieWoodenBench
+      edges:
+        - to: chairWoodBench
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+    # Carpmosia-end - whoopie furniture
 
     - node: redComfBench
       entity: BenchRedComfy
@@ -295,3 +597,28 @@
               doAfter: 1
             - tool: Screwing
               doAfter: 1
+
+    # Carpmosia-start - whoopie furniture
+    - node: chairXeno
+      entity: ChairXeno
+      edges:
+        - to: chairXenoWhoopie
+          steps:
+            - tag: WhoopieCushion
+              name: construction-graph-tag-whoopie-cushion
+              icon:
+                sprite: Objects/Fun/whoopie.rsi
+                state: icon
+              doAfter: 1
+
+    - node: chairXenoWhoopie
+      entity: WhoopieChairXeno
+      edges:
+        - to: chairXeno
+          completed:
+            - !type:SpawnPrototype
+              prototype: WhoopieCushion
+          steps:
+            - tool: Prying
+              doAfter: 1
+# Carpmosia-end - whoopie furniture

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
@@ -103,7 +103,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: chairWhoopie
           steps:
             - tag: WhoopieCushion
@@ -123,7 +123,6 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
 
     - node: chairGreyscale
       entity: ChairGreyscale
@@ -135,7 +134,6 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
         - to: chairGreyscaleWhoopie
           steps:
             - tag: WhoopieCushion
@@ -155,7 +153,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
 
     - node: stool
       entity: Stool
@@ -167,7 +165,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: stoolWhoopie
           steps:
             - tag: WhoopieCushion
@@ -187,7 +185,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
 
     - node: stoolBar
       entity: StoolBar
@@ -199,7 +197,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: stoolBarWhoopie
           steps:
             - tag: WhoopieCushion
@@ -219,7 +217,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
 
     - node: chairBrass
       entity: ChairBrass
@@ -231,7 +229,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: chairBrassWhoopie
           steps:
             - tag: WhoopieCushion
@@ -251,7 +249,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
 
     - node: chairOffice
       entity: ChairOfficeLight
@@ -264,7 +262,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: chairOfficeWhoopie
           steps:
             - tag: WhoopieCushion
@@ -284,7 +282,8 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
+
     - node: chairOfficeDark
       entity: ChairOfficeDark
       edges:
@@ -296,7 +295,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: chairOfficeDarkWhoopie
           steps:
             - tag: WhoopieCushion
@@ -316,7 +315,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
     - node: chairComfy
       entity: ComfyChair
       edges:
@@ -328,7 +327,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: chairComfyWhoopie
           steps:
             - tag: WhoopieCushion
@@ -348,7 +347,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
 
     - node: chairPilotSeat
       entity: ChairPilotSeat
@@ -361,7 +360,7 @@
           steps:
             - tool: Screwing
               doAfter: 2
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: chairPilotSeatWhoopie
           steps:
             - tag: WhoopieCushion
@@ -381,7 +380,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
 
     - node: chairWood
       entity: ChairWood
@@ -394,7 +393,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: chairWoodWhoopie
           steps:
             - tag: WhoopieCushion
@@ -414,7 +413,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
 
     - node: chairMeat
       entity: ChairMeat
@@ -427,7 +426,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: chairMeatWhoopie
           steps:
             - tag: WhoopieCushion
@@ -447,7 +446,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
 
     - node: chairFolding
       entity: ChairFolding
@@ -475,7 +474,7 @@
           steps:
             - tool: Screwing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: chairSteelBenchWhoopie
           steps:
             - tag: WhoopieCushion
@@ -495,7 +494,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
 
     - node: stoolCard
       entity: CardStool
@@ -510,7 +509,7 @@
           steps:
             - tool: Slicing
               doAfter: 1
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: stoolCardWhoopie
           steps:
             - tag: WhoopieCushion
@@ -530,7 +529,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
 
     - node: chairWoodBench
       entity: WoodenBench
@@ -543,7 +542,7 @@
           steps:
             - tool: Screwing
               doAfter: 2
-        # Carpmosia-start - whoopie furniture
+    # Carpmosia-start - whoopie furniture
         - to: chairWoodBenchWhoopie
           steps:
             - tag: WhoopieCushion
@@ -563,7 +562,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-        # Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture
 
     - node: redComfBench
       entity: BenchRedComfy

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
@@ -316,6 +316,7 @@
             - tool: Prying
               doAfter: 1
     # Carpmosia-end - whoopie furniture
+
     - node: chairComfy
       entity: ComfyChair
       edges:

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
@@ -123,6 +123,7 @@
           steps:
             - tool: Prying
               doAfter: 1
+        # Carpmosia-end - whoopie furniture
 
     - node: chairGreyscale
       entity: ChairGreyscale
@@ -154,7 +155,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-  # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
 
     - node: stool
       entity: Stool
@@ -186,7 +187,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-    # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
 
     - node: stoolBar
       entity: StoolBar
@@ -218,7 +219,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-    # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
 
     - node: chairBrass
       entity: ChairBrass
@@ -250,7 +251,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-    # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
 
     - node: chairOffice
       entity: ChairOfficeLight
@@ -283,7 +284,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-    # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
     - node: chairOfficeDark
       entity: ChairOfficeDark
       edges:
@@ -315,7 +316,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-    # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
     - node: chairComfy
       entity: ComfyChair
       edges:
@@ -347,7 +348,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-    # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
 
     - node: chairPilotSeat
       entity: ChairPilotSeat
@@ -380,7 +381,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-    # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
 
     - node: chairWood
       entity: ChairWood
@@ -413,7 +414,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-    # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
 
     - node: chairMeat
       entity: ChairMeat
@@ -446,7 +447,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-    # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
 
     - node: chairFolding
       entity: ChairFolding
@@ -494,7 +495,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-    # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
 
     - node: stoolCard
       entity: CardStool
@@ -529,7 +530,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-    # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
 
     - node: chairWoodBench
       entity: WoodenBench
@@ -562,7 +563,7 @@
           steps:
             - tool: Prying
               doAfter: 1
-    # Carpmosia-end - whoopie furniture
+        # Carpmosia-end - whoopie furniture
 
     - node: redComfBench
       entity: BenchRedComfy
@@ -621,4 +622,4 @@
           steps:
             - tool: Prying
               doAfter: 1
-# Carpmosia-end - whoopie furniture
+    # Carpmosia-end - whoopie furniture

--- a/Resources/Prototypes/_Carpmosia/Entities/Structures/Furniture/whoopieFurniture.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Structures/Furniture/whoopieFurniture.yml
@@ -21,8 +21,7 @@
   - &whoopieDestructible
     type: Destructible
     thresholds:
-    - trigger:
-        !type:DamageTrigger
+    - trigger: !type:DamageTrigger
         damage: 50
       behaviors:
       - !type:DoActsBehavior
@@ -57,8 +56,7 @@
     node: dogbedWhoopie
   - type: Destructible
     thresholds:
-    - trigger:
-        !type:DamageTrigger
+    - trigger: !type:DamageTrigger
         damage: 75
       behaviors:
       - !type:DoActsBehavior
@@ -99,8 +97,7 @@
     placeCentered: true
   - type: Destructible
     thresholds:
-    - trigger:
-        !type:DamageTrigger
+    - trigger: !type:DamageTrigger
         damage: 75
       behaviors:
       - !type:DoActsBehavior
@@ -221,8 +218,7 @@
     node: chairWoodWhoopie
   - type: Destructible
     thresholds:
-    - trigger:
-        !type:DamageTrigger
+    - trigger: !type:DamageTrigger
         damage: 25
       behaviors:
       - !type:DoActsBehavior
@@ -266,8 +262,7 @@
   components:
   - type: Destructible
     thresholds:
-    - trigger:
-        !type:DamageTrigger
+    - trigger: !type:DamageTrigger
         damage: 10
       behaviors:
       - !type:SpawnEntitiesBehavior
@@ -291,8 +286,7 @@
   components:
   - type: Destructible
     thresholds:
-    - trigger:
-        !type:DamageTrigger
+    - trigger: !type:DamageTrigger
         damage: 50
       behaviors:
       - !type:DoActsBehavior

--- a/Resources/Prototypes/_Carpmosia/Entities/Structures/Furniture/whoopieFurniture.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Structures/Furniture/whoopieFurniture.yml
@@ -1,8 +1,7 @@
 - type: entity #whoopie component. adding this as additional parent and then we have haha-fartbuckle.
-  name: Whoopie Base
-  suffix: whoopie
   abstract: true
   id: WhoopieBase
+  suffix: whoopie
   components:
   - type: Strap
     buckleSound:
@@ -47,7 +46,6 @@
 - type: entity
   parent: [DogBed, WhoopieBase]
   id: WhoopieDogBed
-  name: dog bed
   components:
   - type: Construction
     graph: bed
@@ -74,7 +72,6 @@
 - type: entity
   parent: [WhoopieBase, Mattress]
   id: WhoopieMattress
-  name: mattress
   components:
   - type: Construction
     graph: bed
@@ -85,7 +82,6 @@
 - type: entity
   parent: [PsychBed, WhoopieBase]
   id: WhoopiePsychBed
-  name: psychologist bed
   components:
   - type: Construction
     graph: bed
@@ -110,19 +106,16 @@
 
 #seats/chairs
 - type: entity
-  name: chair
-  suffix: whoopie
-  id: WhoopieChair
   parent: [WhoopieBase, Chair]
+  id: WhoopieChair
   components:
   - type: Construction
     graph: Seat
     node: chairWhoopie
 
 - type: entity 
-  name: chair
-  id: WhoopieChairGreyscale
   parent: [WhoopieBase, ChairGreyscale]
+  id: WhoopieChairGreyscale
   suffix: White, whoopie
   components:
   - type: Construction
@@ -130,36 +123,32 @@
     node: chairGreyscaleWhoopie
 
 - type: entity 
-  name: stool
-  id: WhoopieStool
   parent: [WhoopieBase, Stool]
+  id: WhoopieStool
   components:
   - type: Construction
     graph: Seat
     node: stoolWhoopie
 
 - type: entity
-  name: bar stool
-  id: WhoopieBarStool
   parent: [WhoopieBase, StoolBar]
+  id: WhoopieBarStool
   components:
   - type: Construction
     graph: Seat
     node: stoolBarWhoopie
 
 - type: entity
-  name: brass chair
-  id: WhoopieChairBrass
   parent: [WhoopieBase, ChairBrass]
+  id: WhoopieChairBrass
   components:
   - type: Construction
     graph: Seat
     node: chairBrassWhoopie
 
 - type: entity
-  name: white office chair
-  id: WhoopieChairOfficeLight
   parent: [WhoopieBase, OfficeChairBase]
+  id: WhoopieChairOfficeLight
   components:
   - type: Construction
     graph: Seat
@@ -168,38 +157,32 @@
     state: office-white
 
 - type: entity 
-  name: dark office chair
-  suffix: whoopie
-  id: WhoopieChairOfficeDark
   parent: [WhoopieBase, ChairOfficeDark]
+  id: WhoopieChairOfficeDark
   components:
   - type: Construction
     graph: Seat
     node: chairOfficeDarkWhoopie
 
 - type: entity
-  name: comfy chair
-  suffix: whoopie
-  id: WhoopieComfyChair
   parent: [WhoopieBase, ComfyChair]
+  id: WhoopieComfyChair
   components:
   - type: Construction
     graph: Seat
     node: chairComfyWhoopie
 
 - type: entity
-  name: pilot seat
-  suffix: whoopie
-  id: WhoopieChairPilotSeat
   parent: [WhoopieBase, ChairPilotSeat]
+  id: WhoopieChairPilotSeat
   components:
   - type: Construction
     graph: Seat
     node: chairPilotSeatWhoopie
 
 - type: entity
-  id: WhoopieChairWood
   parent: [ChairWood, WhoopieBase]
+  id: WhoopieChairWood
   components:
   - type: Construction
     graph: Seat
@@ -224,27 +207,24 @@
             max: 1
 
 - type: entity
-  name: meat chair
-  id: WhoopieChairMeat
   parent: [WhoopieBase, ChairMeat]
+  id: WhoopieChairMeat
   components:
   - type: Construction
     graph: Seat
     node: chairMeatWhoopie
 
 - type: entity
-  name: steel bench
-  id: WhoopieSteelBench
   parent: [WhoopieBase, SteelBench]
+  id: WhoopieSteelBench
   components:
   - type: Construction
     graph: Seat
     node: chairSteelBenchWhoopie
 
 - type: entity
-  name: cardboard stool
-  id: WhoopieCardStool
   parent: [CardStool, WhoopieBase]
+  id: WhoopieCardStool
   components:
   - type: Destructible
     thresholds:
@@ -266,9 +246,8 @@
     node: stoolCardWhoopie
 
 - type: entity
-  name: wooden bench
-  id: WhoopieWoodenBench
   parent: [WoodenBench, WhoopieBase]
+  id: WhoopieWoodenBench
   components:
   - type: Destructible
     thresholds:
@@ -293,7 +272,6 @@
     node: chairWoodBenchWhoopie
 
 - type: entity
-  name: xeno chair
   parent: [WhoopieBase, ChairXeno]
   id: WhoopieChairXeno
   components:

--- a/Resources/Prototypes/_Carpmosia/Entities/Structures/Furniture/whoopieFurniture.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Structures/Furniture/whoopieFurniture.yml
@@ -1,0 +1,323 @@
+- type: entity #whoopie component. adding this as additional parent and then we have haha-fartbuckle.
+  name: Whoopie Base
+  suffix: whoopie
+  abstract: true
+  id: WhoopieBase
+  components:
+  - type: Strap
+    buckleSound:
+      collection: Parp
+      params:
+        variation: 0.125
+
+#beds
+- type: entity 
+  parent: [Bed, WhoopieBase]
+  id: WhoopieBed
+  components:
+  - type: Construction
+    graph: bed
+    node: bedWhoopie
+  - &whoopieDestructible
+    type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          WhoopieCushion:
+            min: 1
+            max: 1
+
+- type: entity
+  parent: [MedicalBed, WhoopieBase]
+  id: WhoopieMedicalBed
+  components:
+  - type: Construction
+    graph: bed
+    node: medicalbedWhoopie
+  - type: PlaceableSurface # has to be redefined here after Construction or constructing wont work (dang.)
+    placeCentered: true
+  - *whoopieDestructible
+
+- type: entity
+  parent: [DogBed, WhoopieBase]
+  id: WhoopieDogBed
+  name: dog bed
+  components:
+  - type: Construction
+    graph: bed
+    node: dogbedWhoopie
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 75
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WoodDestroy
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MaterialWoodPlank:
+            min: 1
+            max: 5
+          WhoopieCushion:
+            min: 1
+            max: 1
+
+- type: entity
+  parent: [Mattress, WhoopieBase]
+  id: WhoopieMattress
+  name: mattress
+  components:
+  - type: Construction
+    graph: bed
+    node: mattressWhoopie
+  - type: PlaceableSurface # has to be redefined here after Construction or constructing wont work (dang.)
+    placeCentered: true
+  - *whoopieDestructible
+
+- type: entity
+  parent: [PsychBed, WhoopieBase]
+  id: WhoopiePsychBed
+  name: psychologist bed
+  components:
+  - type: Construction
+    graph: bed
+    node: psychbedWhoopie
+  - type: PlaceableSurface # same here
+    placeCentered: true
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 75
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MaterialWoodPlank:
+            min: 2
+            max: 2
+          WhoopieCushion:
+            min: 1
+            max: 1
+
+#seats/chairs
+- type: entity
+  name: chair
+  suffix: whoopie
+  id: WhoopieChair
+  parent: [Chair, WhoopieBase]
+  components:
+  - type: Construction
+    graph: Seat
+    node: chairWhoopie
+  - *whoopieDestructible
+
+- type: entity 
+  name: chair
+  id: WhoopieChairGreyscale
+  parent: [ChairGreyscale, WhoopieBase]
+  suffix: White, whoopie
+  components:
+  - type: Construction
+    graph: Seat
+    node: chairGreyscaleWhoopie
+  - *whoopieDestructible
+
+- type: entity 
+  name: stool
+  id: WhoopieStool
+  parent: [Stool, WhoopieBase]
+  components:
+  - type: Construction
+    graph: Seat
+    node: stoolWhoopie
+  - *whoopieDestructible
+
+- type: entity
+  name: bar stool
+  id: WhoopieBarStool
+  parent: [StoolBar, WhoopieBase]
+  components:
+  - type: Construction
+    graph: Seat
+    node: stoolBarWhoopie
+  - *whoopieDestructible
+
+- type: entity
+  name: brass chair
+  id: WhoopieChairBrass
+  parent: [ChairBrass, WhoopieBase]
+  components:
+  - type: Construction
+    graph: Seat
+    node: chairBrassWhoopie
+  - *whoopieDestructible
+
+- type: entity
+  name: white office chair
+  id: WhoopieChairOfficeLight
+  parent: [OfficeChairBase, WhoopieBase]
+  components:
+  - type: Construction
+    graph: Seat
+    node: chairOfficeWhoopie
+  - type: Sprite
+    state: office-white
+  - *whoopieDestructible
+
+- type: entity 
+  name: dark office chair
+  suffix: whoopie
+  id: WhoopieChairOfficeDark
+  parent: [ChairOfficeDark, WhoopieBase]
+  components:
+  - type: Construction
+    graph: Seat
+    node: chairOfficeDarkWhoopie
+  - *whoopieDestructible
+
+- type: entity
+  name: comfy chair
+  suffix: whoopie
+  id: WhoopieComfyChair
+  parent: [ComfyChair, WhoopieBase]
+  components:
+  - type: Construction
+    graph: Seat
+    node: chairComfyWhoopie
+  - *whoopieDestructible
+
+- type: entity
+  name: pilot seat
+  suffix: whoopie
+  id: WhoopieChairPilotSeat
+  parent: [ChairPilotSeat, WhoopieBase]
+  components:
+  - type: Construction
+    graph: Seat
+    node: chairPilotSeatWhoopie
+  - *whoopieDestructible
+
+- type: entity
+  id: WhoopieChairWood
+  parent: [ChairWood, WhoopieBase]
+  components:
+  - type: Construction
+    graph: Seat
+    node: chairWoodWhoopie
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 25
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WoodDestroy
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MaterialWoodPlank:
+            min: 1
+            max: 1
+          WhoopieCushion:
+            min: 1
+            max: 1
+
+- type: entity
+  name: meat chair
+  id: WhoopieChairMeat
+  parent: [ChairMeat, WhoopieBase]
+  components:
+  - type: Construction
+    graph: Seat
+    node: chairMeatWhoopie
+  - *whoopieDestructible
+
+- type: entity
+  name: steel bench
+  id: WhoopieSteelBench
+  parent: [SteelBench, WhoopieBase]
+  components:
+  - type: Construction
+    graph: Seat
+    node: chairSteelBenchWhoopie
+  - *whoopieDestructible
+
+- type: entity
+  name: cardboard stool
+  id: WhoopieCardStool
+  parent: [CardStool, WhoopieBase]
+  components:
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 10
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MaterialCardboard:
+            min: 1
+            max: 2
+          WhoopieCushion:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: Construction
+    graph: Seat
+    node: stoolCardWhoopie
+
+- type: entity
+  name: wooden bench
+  id: WhoopieWoodenBench
+  parent: [WoodenBench, WhoopieBase]
+  components:
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: WoodDestroy
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          MaterialWoodPlank:
+            min: 2
+            max: 4
+          WhoopieCushion:
+            min: 1
+            max: 1
+  - type: Construction
+    graph: Seat
+    node: chairWoodBenchWhoopie
+
+- type: entity
+  name: xeno chair
+  parent: [ChairXeno, WhoopieBase]
+  id: WhoopieChairXeno
+  components:
+  - type: Construction
+    graph: Seat
+    node: chairXenoWhoopie
+  - *whoopieDestructible

--- a/Resources/Prototypes/_Carpmosia/Entities/Structures/Furniture/whoopieFurniture.yml
+++ b/Resources/Prototypes/_Carpmosia/Entities/Structures/Furniture/whoopieFurniture.yml
@@ -9,17 +9,7 @@
       collection: Parp
       params:
         variation: 0.125
-
-#beds
-- type: entity 
-  parent: [Bed, WhoopieBase]
-  id: WhoopieBed
-  components:
-  - type: Construction
-    graph: bed
-    node: bedWhoopie
-  - &whoopieDestructible
-    type: Destructible
+  - type: Destructible
     thresholds:
     - trigger: !type:DamageTrigger
         damage: 50
@@ -35,8 +25,17 @@
             min: 1
             max: 1
 
+#beds
 - type: entity
-  parent: [MedicalBed, WhoopieBase]
+  parent: [WhoopieBase, Bed]
+  id: WhoopieBed
+  components:
+  - type: Construction
+    graph: bed
+    node: bedWhoopie
+
+- type: entity
+  parent: [WhoopieBase, MedicalBed]
   id: WhoopieMedicalBed
   components:
   - type: Construction
@@ -44,7 +43,6 @@
     node: medicalbedWhoopie
   - type: PlaceableSurface # has to be redefined here after Construction or constructing wont work (dang.)
     placeCentered: true
-  - *whoopieDestructible
 
 - type: entity
   parent: [DogBed, WhoopieBase]
@@ -74,7 +72,7 @@
             max: 1
 
 - type: entity
-  parent: [Mattress, WhoopieBase]
+  parent: [WhoopieBase, Mattress]
   id: WhoopieMattress
   name: mattress
   components:
@@ -83,7 +81,6 @@
     node: mattressWhoopie
   - type: PlaceableSurface # has to be redefined here after Construction or constructing wont work (dang.)
     placeCentered: true
-  - *whoopieDestructible
 
 - type: entity
   parent: [PsychBed, WhoopieBase]
@@ -116,98 +113,89 @@
   name: chair
   suffix: whoopie
   id: WhoopieChair
-  parent: [Chair, WhoopieBase]
+  parent: [WhoopieBase, Chair]
   components:
   - type: Construction
     graph: Seat
     node: chairWhoopie
-  - *whoopieDestructible
 
 - type: entity 
   name: chair
   id: WhoopieChairGreyscale
-  parent: [ChairGreyscale, WhoopieBase]
+  parent: [WhoopieBase, ChairGreyscale]
   suffix: White, whoopie
   components:
   - type: Construction
     graph: Seat
     node: chairGreyscaleWhoopie
-  - *whoopieDestructible
 
 - type: entity 
   name: stool
   id: WhoopieStool
-  parent: [Stool, WhoopieBase]
+  parent: [WhoopieBase, Stool]
   components:
   - type: Construction
     graph: Seat
     node: stoolWhoopie
-  - *whoopieDestructible
 
 - type: entity
   name: bar stool
   id: WhoopieBarStool
-  parent: [StoolBar, WhoopieBase]
+  parent: [WhoopieBase, StoolBar]
   components:
   - type: Construction
     graph: Seat
     node: stoolBarWhoopie
-  - *whoopieDestructible
 
 - type: entity
   name: brass chair
   id: WhoopieChairBrass
-  parent: [ChairBrass, WhoopieBase]
+  parent: [WhoopieBase, ChairBrass]
   components:
   - type: Construction
     graph: Seat
     node: chairBrassWhoopie
-  - *whoopieDestructible
 
 - type: entity
   name: white office chair
   id: WhoopieChairOfficeLight
-  parent: [OfficeChairBase, WhoopieBase]
+  parent: [WhoopieBase, OfficeChairBase]
   components:
   - type: Construction
     graph: Seat
     node: chairOfficeWhoopie
   - type: Sprite
     state: office-white
-  - *whoopieDestructible
 
 - type: entity 
   name: dark office chair
   suffix: whoopie
   id: WhoopieChairOfficeDark
-  parent: [ChairOfficeDark, WhoopieBase]
+  parent: [WhoopieBase, ChairOfficeDark]
   components:
   - type: Construction
     graph: Seat
     node: chairOfficeDarkWhoopie
-  - *whoopieDestructible
 
 - type: entity
   name: comfy chair
   suffix: whoopie
   id: WhoopieComfyChair
-  parent: [ComfyChair, WhoopieBase]
+  parent: [WhoopieBase, ComfyChair]
   components:
   - type: Construction
     graph: Seat
     node: chairComfyWhoopie
-  - *whoopieDestructible
 
 - type: entity
   name: pilot seat
   suffix: whoopie
   id: WhoopieChairPilotSeat
-  parent: [ChairPilotSeat, WhoopieBase]
+  parent: [WhoopieBase, ChairPilotSeat]
   components:
   - type: Construction
     graph: Seat
     node: chairPilotSeatWhoopie
-  - *whoopieDestructible
 
 - type: entity
   id: WhoopieChairWood
@@ -238,22 +226,20 @@
 - type: entity
   name: meat chair
   id: WhoopieChairMeat
-  parent: [ChairMeat, WhoopieBase]
+  parent: [WhoopieBase, ChairMeat]
   components:
   - type: Construction
     graph: Seat
     node: chairMeatWhoopie
-  - *whoopieDestructible
 
 - type: entity
   name: steel bench
   id: WhoopieSteelBench
-  parent: [SteelBench, WhoopieBase]
+  parent: [WhoopieBase, SteelBench]
   components:
   - type: Construction
     graph: Seat
     node: chairSteelBenchWhoopie
-  - *whoopieDestructible
 
 - type: entity
   name: cardboard stool
@@ -308,10 +294,9 @@
 
 - type: entity
   name: xeno chair
-  parent: [ChairXeno, WhoopieBase]
+  parent: [WhoopieBase, ChairXeno]
   id: WhoopieChairXeno
   components:
   - type: Construction
     graph: Seat
     node: chairXenoWhoopie
-  - *whoopieDestructible

--- a/Resources/Prototypes/_Carpmosia/tags.yml
+++ b/Resources/Prototypes/_Carpmosia/tags.yml
@@ -6,3 +6,6 @@
 
 - type: Tag
   id: HudDiagnostic # Diagnostics goggles recipe :3
+
+- type: Tag
+  id: WhoopieCushion # Used to upgrade chairs and beds to whoopie version. -Whoopie furniture


### PR DESCRIPTION
## General information
Adds construction graphs, recipes, and prototypes to allow upgrading chairs and beds with whoopie cushions.

---

## Why / Balance
Adds more options for clowning and fun base-building mechanics. Players can now turn normal seating areas into traps or comedy hubs. **honk**

---

## Technical details
- Added `whoopieFurniture.yml` for Entity definitions.
- Set up an abstract base Entity (`WhoopieBase`) to put as second parent.
- Updated construction graphs (`bed.yml` and `seats.yml`) to handle the upgrade paths.
- Added string in `tags.ftl`. im not sure if I even need this. but I did.
- Added the Tag `WhoopieCushion` to the Entity `WhoopieCushion`
- Added the Tag `WhoopieCushion`to `Tags.yml`

---

## Test plan
- Spawned all Whoopie chair/bed in-game. (search `whoopie` to find them all at once, all are suffixed with this term)
- Downgrade it using a Crowbar and interacting with it.
- Re-add the Whoopie Cushion 
- Sit on it to verify the functional behavior and sound triggers.
- Spawn them again and destroy them to verify dropping one Cushion.

---

## Media

https://github.com/user-attachments/assets/0f78900a-542d-456e-b964-c9691fd37f82


---

## Breaking changes
None.

---

## Changelog
🆑
- tweak: Added construction upgrades for chairs and beds to be upgraded with whoopie cushions.