### PR TITLE
Try to improve BuyerAccessCondition

### DIFF
--- a/Content.Server/_Carpmosia/Store/Conditions/BuyerAccessCondition.cs
+++ b/Content.Server/_Carpmosia/Store/Conditions/BuyerAccessCondition.cs
@@ -1,51 +1,72 @@
-using System.Linq;
-using Content.Shared.Store;
+using Content.Shared.Access;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
-using Content.Shared.Emag.Components;
-using Content.Shared.Popups;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
-using Content.Server.Mind;
+using Content.Shared.Emag.Systems;
 using Content.Shared.Mind;
+using Content.Shared.Store;
+using Robust.Shared.Prototypes;
+//using Robust.Shared.Utility;
 
 namespace Content.Server.Store.Conditions;
 
+// TODO: Have emagging an AccessReader actually leave an EmagComponent so this can properly check that.
+
 /// <summary>
 /// Allows a store entry to be filtered out based on the user's access.
-/// Supports only AccessReader
+/// Supports entities without an <see cref="AccessReaderComponent"/> if this has an access set.
 /// </summary>
 public sealed partial class BuyerAccessCondition : ListingCondition
 {
-    [DataField("access", required: false)]
-    public string? access = null;
+    private AccessReaderSystem? _accessReader;
+    private EmagSystem? _emag;
+
+    /// <summary>
+    /// The access needed for this condition to pass. If null, uses the <see cref="AccessReaderComponent"/> if it's there, otherwise defaults to true.
+    /// </summary>
+    [DataField]
+    public ProtoId<AccessLevelPrototype>? Access;
+
+    ///// <summary>
+    ///// Wether or not this should break when access broken. Needs an access set to work. If left null, defaults first to the value on <see cref="AccessReaderComponent"/>, then to true.
+    ///// </summary>
+    //[DataField]
+    //public bool? BreakOnAccessBreaker;
 
     public override bool Condition(ListingConditionArgs args)
     {
-        var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
+        if (args.StoreEntity == null)
+            return true;
+
         var ent = args.EntityManager;
 
-        if (!ent.TryGetComponent<MindComponent>(args.Buyer, out var mind)
-            || mind.CurrentEntity is null) return false;
-        var buyer = mind.CurrentEntity.Value;
-
-        var _accessReader = ent.System<AccessReaderSystem>();
-
-        if (args.StoreEntity == null
-            || !ent.TryGetComponent<AccessReaderComponent>(args.StoreEntity, out var accessReader))
+        if (!ent.TryGetComponent<MindComponent>(args.Buyer, out var mind) || mind.CurrentEntity is null) // Buyer either as no mind or no attached entity, handle elsewhere.
             return true;
 
-        if (access != null)
+
+        _accessReader ??= ent.System<AccessReaderSystem>();
+        _emag ??= ent.System<EmagSystem>(); // Has a public Sawmill so I figured I'd keep it for now.
+
+        var buyer = mind.CurrentEntity.Value;
+        _accessReader.GetMainAccessReader(args.StoreEntity.Value, out var accessReader);
+
+        //DebugTools.Assert(BreakOnAccessBreaker == null || Access != null, "BuyerAccessCondtion set BreakOnAccessBreaker but not Access.");
+
+        if (Access != null)
         {
-            var accesses = _accessReader.FindAccessTags(buyer);
-            if (accesses.Any(a => a.ToString() == access))
-                return true;
+            //var checkEmag = BreakOnAccessBreaker ?? accessReader == null || accessReader.Value.Comp.BreakOnAccessBreaker;
+
+            //return checkEmag && _emag.CheckFlag(args.StoreEntity.Value, EmagType.Access)
+            //       || _accessReader.FindAccessTags(buyer).Contains(Access.Value);
+
+            return _accessReader.FindAccessTags(buyer).Contains(Access.Value);
         }
 
-        else if (_accessReader.IsAllowed(buyer, args.StoreEntity.Value, accessReader)
-                || ent.HasComponent<EmaggedComponent>(args.StoreEntity.Value))
-            return true;
+        if (accessReader != null)
+        {
+            return _accessReader.IsAllowed(buyer, accessReader.Value, accessReader);
+        }
 
-        return false;
+        _emag.Log.Error("BuyerAccessCondition couldn't find an access to check against.");
+        return true;
     }
 }


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Title, mostly just trying to make this more consistent with other conditions.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Had some parts that were unused or could be safely replaced with more modern things, felt like I'd try to brush up the rest of it as well.
Partly got rid of the TryGetComponents in case their systems switch to using queries internally.

## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->
Tried to store AccessReaderSystem (and now EmagSystem) instead of getting them every time, tried to clarify some things with comments, and added support for things without AccessReaderComponent as long as this has an access set. Also made this default to true when it finds nothing to check against, but log an error when doing so.
Switched from using a TryGetComponent<AccessReaderComponent> to GetMainAccessReader.
Would have switched from TryGetComponent<EmaggedComponent> to CheckFlag but AccessReaderComponent prevents EmaggedComponent from getting added.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Use the VendingStoreSalvage I guess, mess with the Access field on a listing to make sure that works as well.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
Shouldn't be noticeable.
