### PR TITLE
Make anomaly generator emag-able

### DIFF
--- a/Content.Client/Anomaly/Ui/AnomalyGeneratorWindow.xaml.cs
+++ b/Content.Client/Anomaly/Ui/AnomalyGeneratorWindow.xaml.cs
@@ -53,6 +53,12 @@ public sealed partial class AnomalyGeneratorWindow : FancyWindow
     {
         if (_timing.CurTime > _cooldownEnd)
         {
+            // Carpmosia-start - Emagging anomaly generators
+            if (GenerateButton.Disabled)
+            {
+                UpdateReady();
+            }
+            // Carpmosia-end - Emagging anomaly generators
             CooldownLabel.SetMarkup(Loc.GetString("anomaly-generator-no-cooldown"));
         }
         else

--- a/Content.Server/Anomaly/AnomalySystem.Generator.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Generator.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Content.Shared.Power;
+using Content.Shared.Emag.Systems;
 
 namespace Content.Server.Anomaly;
 
@@ -30,8 +31,18 @@ public sealed partial class AnomalySystem
         SubscribeLocalEvent<AnomalyGeneratorComponent, MaterialAmountChangedEvent>(OnGeneratorMaterialAmountChanged);
         SubscribeLocalEvent<AnomalyGeneratorComponent, AnomalyGeneratorGenerateButtonPressedEvent>(OnGenerateButtonPressed);
         SubscribeLocalEvent<AnomalyGeneratorComponent, PowerChangedEvent>(OnGeneratorPowerChanged);
+        SubscribeLocalEvent<AnomalyGeneratorComponent, GotEmaggedEvent>(OnEmagged); // Carpmosia-edit - Emagging anomaly generators
         SubscribeLocalEvent<GeneratingAnomalyGeneratorComponent, ComponentStartup>(OnGeneratingStartup);
     }
+
+    // Carpmosia-start - Emagging anomaly generators
+    private void OnEmagged(Entity<AnomalyGeneratorComponent> ent, ref GotEmaggedEvent args)
+    {
+        ent.Comp.CooldownLength = ent.Comp.GenerationLength;
+        ent.Comp.CooldownEndTime = TimeSpan.Zero;
+        args.Handled = true;
+    }
+    // Carpmosia-end - Emagging anomaly generators
 
     private void OnGeneratorPowerChanged(EntityUid uid, AnomalyGeneratorComponent component, ref PowerChangedEvent args)
     {


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Made anomaly generator emag-able, which reduces the 5 minute cooldown to 8 seconds (length of animation)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Could help with the critting anoms objective, as well as a potential to cause some chaos.

## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example:
       - [ ] Resprited X and Y to work with this change.
       - [ ] Implemented Z and X to handle Y edge case.
       - [ ] Added a new component for all X to prevent Z. -->
- [x] Made anomaly generator replace CooldownLength with GenerationLength when emagged, also set CooldownEndTime to zero so there isnt a leftover cooldown if generator was used previously.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Start server, go to science, emag the generator and have fun

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->
Nah

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->
No

## Changelog
<!-- Edit this to cover all player facing changes in a concise and short matter.
       Feel free to remove or add as many add, remove, fix, tweak lines as you need.
       If there are no player facing changes, you can remove it altogether.
       This will be visible in-game and on Discord. -->
:cl:
- add: Anomaly generator can now be EMAG-ed to remove the 5 minute safety cooldown.
