### PR TITLE
Fix cargo bounty arbitrage on random instrument crate (#546)

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -129,9 +129,10 @@
           tableId: WoodwindInstrumentTable # 200 speso max
         - !type:NestedSelector
           tableId: KeyedPercussionInstrumentTable # 300 speso max
+        # Carpmosia-edit - Fix cargo bounty arbitrage #546 (max 3 percussion instruments per crate, below the 4 needed for BountyPercussion)
         - !type:NestedSelector
-          tableId: SpecialInstrumentTable # x2 200 speso max
-          rolls: 2
+          tableId: SpecialInstrumentTable # x1 200 speso max
+          rolls: 1
 
 # Rest of the fun
 


### PR DESCRIPTION
Closes #546

## Root cause

The NoCargoBountyArbitrageTest reports an arbitrage on the random instrument crate. CrateFunInstrumentsRandom can roll 4 percussion-tagged instruments in one crate. This set completes the BountyPercussion cargo bounty, which pays 2500 credits for a crate that costs 2000.

This regression came from upstream SS14 PR #43949. That change raised the SpecialInstrumentTable rolls from 1 to 2.

## Fix

Set the SpecialInstrumentTable rolls from 2 back to 1 in the CrateFunInstrumentsRandom fill.

The maximum percussion count per crate drops from 4 to 3. BountyPercussion needs 4. The bounty is no longer fulfillable from this crate.

## Alternative fixes considered

Raise the crate cost. This option was rejected. It reduces the value of the crate for every buyer.

Cut the bounty reward. This option was rejected. It changes the cargo economy for all players.

## Upstream reference

space-wizards/space-station-14 issue #44487 describes the same arbitrage. Contributor whatston3 diagnosed the SpecialInstrumentTable rolls as the cause.
