### PR TITLE
Allow aghosts to bypass anchor checks when rotating things

### DIFF
--- a/Content.Shared/Rotatable/RotatableSystem.cs
+++ b/Content.Shared/Rotatable/RotatableSystem.cs
@@ -43,7 +43,7 @@ public sealed partial class RotatableSystem : EntitySystem
             return;
 
         // Check if the object is anchored.
-        if (TryComp<PhysicsComponent>(uid, out var physics) && physics.BodyType == BodyType.Static
+        if (TryComp<PhysicsComponent>(uid, out var physics) && physics.BodyType == BodyType.Static // Carpmosia-edit - Bypass checks for aghosts
             && !HasComp<BypassInteractionChecksComponent>(args.User)) // Carpmosia-edit - Bypass checks for aghosts
             return;
 
@@ -190,7 +190,7 @@ public sealed partial class RotatableSystem : EntitySystem
             return false;
 
         // Check if the object is anchored.
-        if (TryComp<PhysicsComponent>(entity, out var physics) && physics.BodyType == BodyType.Static
+        if (TryComp<PhysicsComponent>(entity, out var physics) && physics.BodyType == BodyType.Static // Carpmosia-edit - Bypass checks for aghosts
             && !HasComp<BypassInteractionChecksComponent>(entity)) // Carpmosia-edit - Bypass checks for aghosts
         {
             _popup.PopupEntity(Loc.GetString("flippable-component-try-flip-is-stuck"), entity, player);

--- a/Content.Shared/Rotatable/RotatableSystem.cs
+++ b/Content.Shared/Rotatable/RotatableSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.ActionBlocker;
 using Content.Shared.Input;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Components; // Carpmosia-edit - Bypass checks for aghosts
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using Robust.Shared.Input.Binding;
@@ -42,7 +43,8 @@ public sealed partial class RotatableSystem : EntitySystem
             return;
 
         // Check if the object is anchored.
-        if (TryComp<PhysicsComponent>(uid, out var physics) && physics.BodyType == BodyType.Static)
+        if (TryComp<PhysicsComponent>(uid, out var physics) && physics.BodyType == BodyType.Static
+            && !HasComp<BypassInteractionChecksComponent>(args.User)) // Carpmosia-edit - Bypass checks for aghosts
             return;
 
         Verb verb = new()
@@ -67,6 +69,7 @@ public sealed partial class RotatableSystem : EntitySystem
 
         // Check if the object is anchored, and whether we are still allowed to rotate it.
         if (!component.RotateWhileAnchored &&
+            !HasComp<BypassInteractionChecksComponent>(args.User) && // Carpmosia-edit - Bypass checks for aghosts
             TryComp<PhysicsComponent>(uid, out var physics) &&
             physics.BodyType == BodyType.Static)
             return;
@@ -136,6 +139,7 @@ public sealed partial class RotatableSystem : EntitySystem
 
         // Check if the object is anchored, and whether we are still allowed to rotate it.
         if (!rotatableComp.RotateWhileAnchored && TryComp<PhysicsComponent>(entity, out var physics) &&
+            !HasComp<BypassInteractionChecksComponent>(entity) && // Carpmosia-edit - Bypass checks for aghosts
             physics.BodyType == BodyType.Static)
         {
             _popup.PopupEntity(Loc.GetString("rotatable-component-try-rotate-stuck"), entity, player);
@@ -161,6 +165,7 @@ public sealed partial class RotatableSystem : EntitySystem
 
         // Check if the object is anchored, and whether we are still allowed to rotate it.
         if (!rotatableComp.RotateWhileAnchored && TryComp<PhysicsComponent>(entity, out var physics) &&
+            !HasComp<BypassInteractionChecksComponent>(entity) && // Carpmosia-edit - Bypass checks for aghosts
             physics.BodyType == BodyType.Static)
         {
             _popup.PopupEntity(Loc.GetString("rotatable-component-try-rotate-stuck"), entity, player);
@@ -185,7 +190,8 @@ public sealed partial class RotatableSystem : EntitySystem
             return false;
 
         // Check if the object is anchored.
-        if (TryComp<PhysicsComponent>(entity, out var physics) && physics.BodyType == BodyType.Static)
+        if (TryComp<PhysicsComponent>(entity, out var physics) && physics.BodyType == BodyType.Static
+            && !HasComp<BypassInteractionChecksComponent>(entity)) // Carpmosia-edit - Bypass checks for aghosts
         {
             _popup.PopupEntity(Loc.GetString("flippable-component-try-flip-is-stuck"), entity, player);
             return false;


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Entities that can be rotated when unanchored can now be rotated even when anchored by aghosts

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
I NEED THIS FOR MAPPING TO CLEANUP ATMOS ON 10 MAPS THIS WILL MAKE MY LIFE SO MUCH EASIER

## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example: -->
- [x] Added some logic to bypass a check for aghosts

## Test plan
<!-- Describe how you tested the pull request, and how someone reviewing this PR can test it themselves. -->
Start a round, aghost, try to rotate an anchored pipe or something

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->
<img width="1024" height="718" alt="image" src="https://github.com/user-attachments/assets/ca542c5b-0f33-400d-b200-2965ad561514" />

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->
No

## Changelog
Not player facing ig
