### PR TITLE
Update evac launch announcement

### DIFF
--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -218,7 +218,7 @@ public sealed partial class EmergencyShuttleSystem
         if (!ShuttlesLeft && _consoleAccumulator <= 0f)
         {
             ShuttlesLeft = true;
-            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("emergency-shuttle-left", ("transitTime", $"{TransitTime:0}")));
+            _chatSystem.DispatchGlobalAnnouncement(Loc.GetString("emergency-shuttle-left-carp", ("transitTime", $"{TransitTime:0}"))); // Carpmosia-edit - Update evac message
 
             Timer.Spawn((int)(TransitTime * 1000) + _bufferTime.Milliseconds, () => _roundEnd.EndRound(), _roundEndCancelToken?.Token ?? default);
         }

--- a/Resources/Locale/en-US/_Carpmosia/shuttles/emergency.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/shuttles/emergency.ftl
@@ -1,0 +1,1 @@
+emergency-shuttle-left-carp = The Emergency Shuttle has left the station. Estimate {$transitTime} seconds until the shuttle arrives at the Terminal.


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Change the announcement made when the evac shuttle is launched to say we are going to the Terminal and not to Centcomm.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Its different so it should be different.
## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example: -->
Changed the local string to point to our own thing.

## Test plan
<!-- Describe how you tested the pull request, and how someone reviewing this PR can test it themselves. -->
Load up map. Callshuttle 1. When it arrives, launch the shuttle from the console. The message is different.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->

## Changelog
:cl: <!-- DO NOT REMOVE THIS LINE UNLESS THERE IS NO CHANGELOG -->
<!-- Edit these as you may need, remove/add as many as you want -->
- tweak: Tweaked the emergency shuttle launch announcement to no longer erroneously state the shuttle is going to Centcomm.
