### PR TITLE
Adjust tesla changes

### DIFF
--- a/Content.Server/Tesla/EntitySystem/TeslaEnergyBallSystem.cs
+++ b/Content.Server/Tesla/EntitySystem/TeslaEnergyBallSystem.cs
@@ -2,7 +2,6 @@ using Content.Server.Administration.Logs;
 using Content.Server.Power.SMES; // Carpmosia-edit - Engine Loose Rework
 using Content.Server.Singularity.Components;
 using Content.Server.Tesla.Components;
-using Content.Shared.Emp; // Carpmosia-edit - Engine Loose Rework
 using Content.Shared.Database;
 using Content.Shared.Singularity.Components;
 using Content.Shared.Mind.Components;
@@ -22,7 +21,6 @@ public sealed partial class TeslaEnergyBallSystem : EntitySystem
 {
     [Dependency] private AudioSystem _audio = default!;
     // Carpmosia-start - Engine Loose Rework
-    [Dependency] private SharedEmpSystem _emp = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private LightningSystem _lightning = default!;
     // Carpmosia-end - Engine Loose Rework
@@ -79,8 +77,7 @@ public sealed partial class TeslaEnergyBallSystem : EntitySystem
         }
 
         _audio.PlayPvs(ent.Comp.SoundExplosion, coords);
-        _emp.EmpPulse(coords, ent.Comp.EmpRange, ent.Comp.EmpConsumption, ent.Comp.EmpDuration);
-        _lightning.ShootRandomLightnings(ent, ent.Comp.EmpRange, ent.Comp.SpawnAmount * 4, arcDepth: 3);
+        _lightning.ShootRandomLightnings(ent, ent.Comp.EmpRange, ent.Comp.SpawnAmount * 2, arcDepth: 3);
 
         QueueDel(ent);
     }


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Removed the EMP effect, toned down the random lightning strikes when the tesla explodes.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
It still does too much, particularly on smaller stations. As said in a staff chat, right now 'the only difference now is instead of the station being destroyed its sitting around in the dark waiting for evac'.
## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example: -->
Cut some stuff and adjusted the number of random lightning strikes.

## Test plan
<!-- Describe how you tested the pull request, and how someone reviewing this PR can test it themselves. -->
Load a map, spawn tesla, watch it go
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->

## Changelog
:cl: <!-- DO NOT REMOVE THIS LINE UNLESS THERE IS NO CHANGELOG -->
<!-- Edit these as you may need, remove/add as many as you want -->
- tweak: Tesla energy balls no longer EMP the station on rupturing, and the number of random lightning strikes it does on rupturing has been reduced
