### PR TITLE
Better map rotation

### DIFF
--- a/Content.Server/Maps/GameMapManager.cs
+++ b/Content.Server/Maps/GameMapManager.cs
@@ -98,7 +98,11 @@ public sealed partial class GameMapManager : IGameMapManager
 
     public IEnumerable<GameMapPrototype> CurrentlyEligibleMaps()
     {
-        var maps = AllVotableMaps().Where(IsMapEligible).ToArray();
+        // Carpmosia-start - Better map rotation
+        var maps = AllVotableMaps().Where(IsMapEligible)
+            .OrderByDescending(x => GetMapRotationQueuePriority(x.ID))
+            .ToArray();
+        // Carpmosia-end - Better map rotation
         return maps.Length == 0 ? AllMaps().Where(x => x.Fallback) : maps;
     }
 
@@ -161,6 +165,11 @@ public sealed partial class GameMapManager : IGameMapManager
         if (!TryLookupMap(gameMap, out var map))
             throw new ArgumentException($"The map \"{gameMap}\" is invalid!");
         _selectedMap = [map]; // Carpmosia-edit - Multistation
+
+        // Carpmosia-start - Better map rotation
+        if (_mapRotationEnabled)
+            EnqueueMap(map.ID);
+        // Carpmosia-end - Better map rotation
     }
 
     public void SelectMapRandom()

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -263,7 +263,7 @@ namespace Content.Server.Voting.Managers
 
         private void CreateMapVote(ICommonSession? initiator)
         {
-            var maps = _gameMapManager.CurrentlyEligibleMaps().ToDictionary(map => map.ID, map => map); // Carpmosia-edit - Better map vote
+            var maps = _gameMapManager.CurrentlyEligibleMaps().Take(3).ToDictionary(map => map.ID, map => map); // Carpmosia-edit - Better map vote
 
             var alone = _playerManager.PlayerCount == 1 && initiator != null;
             var options = new VoteOptions


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Improved map rotation by making map rotation & map voting cross-compatible
CurrentlyEligibleMaps now returns a list sorted based on weight (from map rotation), moving already played maps to the end of the list
Map votes now consider only top N maps available (so during lowpop maps are still available, but during high pop the previous choices are filtered out)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
Force people to actually cycle maps instead of 500 amber rounds, while still preserving map votes

## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example: -->
- [x] Patched map rotation/map vote to work together

## Test plan
<!-- Describe how you tested the pull request, and how someone reviewing this PR can test it themselves. -->
Comment out `map.MinPlayers <= _playerManager.PlayerCount &&` in `Content.Server/Maps/GameMapManager.cs:213`
Switch map pool to `UpstreamMapPool` or smth (Carpmosia map pool is cooked rn)
Wait for map vote to start
Let map vote pass
startround
restartroundnow
Repeat from beginning and see map not present

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->
First round (i chose snowball)
<img width="575" height="248" alt="image" src="https://github.com/user-attachments/assets/76d1d84c-e345-43c8-a7f3-54750842cfd8" />
Second round
<img width="514" height="247" alt="image" src="https://github.com/user-attachments/assets/10b27414-376d-4e41-ba45-64dae330540b" />
Third round (i chose plasma)
<img width="483" height="252" alt="image" src="https://github.com/user-attachments/assets/badd89e5-befd-4e3e-9645-11b9e69a2a50" />
Fourth round
<img width="553" height="239" alt="image" src="https://github.com/user-attachments/assets/3c747d1f-b762-496d-966f-feaca089623d" />

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->

## Changelog
:cl: <!-- DO NOT REMOVE THIS LINE UNLESS THERE IS NO CHANGELOG -->
<!-- Edit these as you may need, remove/add as many as you want -->
- tweak: Map vote options count has been reduced to 3
- tweak: Map vote will now try to hide maps previously voted
