### PR TITLE
Add "rings!" emote and action to the phones

### DIFF
--- a/Resources/Locale/en-US/_Carpmosia/chat/emotes.ftl
+++ b/Resources/Locale/en-US/_Carpmosia/chat/emotes.ftl
@@ -1,13 +1,21 @@
-# Emote Names
+# Tajaran
+## Emote Names
 chat-emote-name-mew = Mew
 chat-emote-name-hiss = Hiss
 chat-emote-name-meow = Meow
 chat-emote-name-purr = Purr
 chat-emote-name-trill = Trill
 
-# Emote Messages
+## Emote Messages
 chat-emote-msg-mew = mews.
 chat-emote-msg-hiss = hisses.
 chat-emote-msg-meow = meows.
 chat-emote-msg-purr = purrs.
 chat-emote-msg-trill = trills.
+
+# Phones
+## Emote Names
+chat-emote-name-phone-ring = Ring
+
+## Emote Messages
+chat-emote-msg-phone-ring = rings!

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_misc.yml
@@ -63,6 +63,14 @@
     notificationPrefix: prayer-chat-notify-centcom
     verb: prayer-verbs-call
     verbImage: null
+  # Carpmosia-start - Phones have ring emote/action
+  - type: Vocal
+    emoteSounds: PhoneRing
+    screamId: PhoneRing  # why does this exist
+    emoteAction: ActionPhoneRing
+  - type: Speech  # this is the best way I can think to make only phones be allowed to ring (alongside `allowed: false` on emote)
+    allowedEmotes: ['PhoneRing']
+  # Carpmosia-end - Phones have ring emote/action
 
 - type: entity
   parent: PhoneInstrument
@@ -76,6 +84,14 @@
   - type: Prayable
     sentMessage: prayer-popup-notify-syndicate-sent
     notificationPrefix: prayer-chat-notify-syndicate
+  # Carpmosia-start - Phones have ring emote/action
+  - type: Vocal
+    emoteSounds: PhoneRing
+    screamId: PhoneRing
+    emoteAction: ActionPhoneRing
+  - type: Speech
+    allowedEmotes: ['PhoneRing']
+  # Carpmosia-end - Phones have ring emote/action
 
 - type: entity
   parent: BaseHandheldInstrument
@@ -181,3 +197,11 @@
     notificationPrefix: prayer-chat-notify-honkmother
     verb: prayer-verbs-call
     verbImage: null
+  # Carpmosia-start - Phones have ring emote/action
+  - type: Vocal
+    emoteSounds: PhoneRing
+    screamId: PhoneRing
+    emoteAction: ActionPhoneRing
+  - type: Speech
+    allowedEmotes: ['PhoneRing']
+  # Carpmosia-end - Phones have ring emote/action

--- a/Resources/Prototypes/_Carpmosia/Actions/phones.yml
+++ b/Resources/Prototypes/_Carpmosia/Actions/phones.yml
@@ -1,0 +1,13 @@
+- type: entity
+  parent: BaseAction
+  id: ActionPhoneRing
+  name: Ring
+  description: Ring ring! Hello?
+  components:
+  - type: Action
+    useDelay: 2
+    icon: Interface/Emotes/Chime.png
+    checkCanInteract: false
+  - type: InstantAction
+    event: !type:EmoteActionEvent
+      emote: PhoneRing

--- a/Resources/Prototypes/_Carpmosia/Actions/phones.yml
+++ b/Resources/Prototypes/_Carpmosia/Actions/phones.yml
@@ -6,7 +6,7 @@
   components:
   - type: Action
     useDelay: 2
-    icon: Interface/Emotes/Chime.png
+    icon: Interface/Emotes/chime.png
     checkCanInteract: false
   - type: InstantAction
     event: !type:EmoteActionEvent

--- a/Resources/Prototypes/_Carpmosia/Voice/SpeechEmoteSounds/phone.yml
+++ b/Resources/Prototypes/_Carpmosia/Voice/SpeechEmoteSounds/phone.yml
@@ -1,0 +1,7 @@
+- type: emoteSounds
+  id: PhoneRing
+  params:
+    variation: 0.1
+  sounds:
+    PhoneRing:
+      path: /Audio/Items/ring.ogg

--- a/Resources/Prototypes/_Carpmosia/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_Carpmosia/Voice/speech_emotes.yml
@@ -128,3 +128,24 @@
   - trilling.
   - trilling!
   - trilling?
+
+- type: emote
+  id: PhoneRing
+  name: chat-emote-name-phone-ring
+  category: Vocal
+  available: false
+  icon: Interface/Emotes/Chime.png
+  chatMessages: ["chat-emote-msg-phone-ring"]
+  chatTriggers:
+  - ring
+  - ring.
+  - ring!
+  - ring?
+  - rings
+  - rings.
+  - rings!
+  - rings?
+  - ringing
+  - ringing.
+  - ringing!
+  - ringing?

--- a/Resources/Prototypes/_Carpmosia/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_Carpmosia/Voice/speech_emotes.yml
@@ -134,7 +134,7 @@
   name: chat-emote-name-phone-ring
   category: Vocal
   available: false
-  icon: Interface/Emotes/Chime.png
+  icon: Interface/Emotes/chime.png
   chatMessages: ["chat-emote-msg-phone-ring"]
   chatTriggers:
   - ring


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Adds an emote with appropriate sound effect to the phones (Red Phone, Blood-Red Phone, and Banana Phone), triggered by emoting `@rings` (or variations of). 
This adds a bit of pizzazz to admemes where an admin has possessed a phone, allowing them to more easily get the attention of players due to the added ringing noise. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
A noise alongside emoting `@rings` is nice. By adding an action it just becomes a button press to trigger it, too. 

## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example: -->
- Added a new Action, `ActionPhoneRing`,
- Added a new emote, `PhoneRing`,
- Added a new emoteSounds, `PhoneRing`,
- Add Vocal and Speech components to each of the 3 phones.
- Tweaked layout of the Carpmosia_ emotes.ftl file to accommodate more future custom emotes

The SFX is just the existing phone ring that plays when a phone is thrown and hits a wall or floor, and the icon for the action is the borg "chime" emote icon. 

## Test plan
<!-- Describe how you tested the pull request, and how someone reviewing this PR can test it themselves. -->
- Find or spawn in one of the phones,
- Right click > Debug > Control,
- Observe the existence of the "Ring" action,
- Use the Ring action, see the emote text "[name] rings!",
- Hear the ring sfx,
- Type variations of `@ring`, `@rings!` into the chat, and
- hear the ring sfx accompanying the emote. 


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->
<img width="326" height="128" alt="image" src="https://github.com/user-attachments/assets/41e961ab-3c3d-4dd4-b130-e9cb579b705c" />


## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->
None. 

## Changelog
:cl: <!-- DO NOT REMOVE THIS LINE UNLESS THERE IS NO CHANGELOG -->
<!-- Edit these as you may need, remove/add as many as you want -->
- add: admin-controlled phones can now audibly ring
