### PR TITLE
Autotagging Disposals

### DIFF
--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
@@ -291,6 +291,11 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
             return false;
         }
 
+        // Carpmosia-start - Better disposals
+        if (TryComp(ent, out DisposalTaggerComponent? tagger))
+            beforeFlushArgs.Tags.Add(tagger.Tag);
+        // Carpmosia-end - Better disposals
+
         var xform = Transform(ent);
 
         if (!TryComp(xform.GridUid, out MapGridComponent? grid))

--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
@@ -56,6 +56,8 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
     [Dependency] private SharedTransformSystem _xform = default!;
     [Dependency] private INetManager _net = default!;
 
+    [Dependency] private EntityQuery<DisposalTaggerComponent> _query = default!; // Carpmosia-edit - Better disposals
+
     public override void Initialize()
     {
         base.Initialize();
@@ -292,7 +294,7 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
         }
 
         // Carpmosia-start - Better disposals
-        if (TryComp(ent, out DisposalTaggerComponent? tagger))
+        if (_query.TryComp(ent, out var tagger))
             beforeFlushArgs.Tags.Add(tagger.Tag);
         // Carpmosia-end - Better disposals
 

--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
@@ -56,8 +56,6 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
     [Dependency] private SharedTransformSystem _xform = default!;
     [Dependency] private INetManager _net = default!;
 
-    [Dependency] private EntityQuery<DisposalTaggerComponent> _taggerQuery = default!; // Carpmosia-edit - Better disposals
-
     public override void Initialize()
     {
         base.Initialize();
@@ -274,6 +272,18 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
         UpdateVisualState(ent);
     }
 
+    // Carpmosia-start - Better disposals
+    /// <summary>
+    /// Auto tags any items sent if there is a DisposalTaggerComponent
+    /// </summary>
+    [SubscribeLocalEvent]
+    private void OnBeforeFlush(Entity<DisposalTaggerComponent> ent, ref BeforeDisposalFlushEvent args)
+    {
+        Dirty(ent);
+        args.Tags.Add(ent.Comp.Tag);
+    }
+    // Carpmosia-end - Better disposals
+
     /// <summary>
     /// Try to flush a disposal unit.
     /// </summary>
@@ -292,11 +302,6 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
             SetEngage(ent, false);
             return false;
         }
-
-        // Carpmosia-start - Better disposals
-        if (_query.TryComp(ent, out var tagger))
-            beforeFlushArgs.Tags.Add(tagger.Tag);
-        // Carpmosia-end - Better disposals
 
         var xform = Transform(ent);
 

--- a/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
+++ b/Content.Shared/Disposal/Unit/SharedDisposalUnitSystem.cs
@@ -56,7 +56,7 @@ public abstract partial class SharedDisposalUnitSystem : EntitySystem
     [Dependency] private SharedTransformSystem _xform = default!;
     [Dependency] private INetManager _net = default!;
 
-    [Dependency] private EntityQuery<DisposalTaggerComponent> _query = default!; // Carpmosia-edit - Better disposals
+    [Dependency] private EntityQuery<DisposalTaggerComponent> _taggerQuery = default!; // Carpmosia-edit - Better disposals
 
     public override void Initialize()
     {

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -137,6 +137,10 @@
     table: !type:NestedSelector
       tableId: RatKingLoot
   - type: RequireProjectileTarget
+  # Carpmosia-start - Better disposals
+  - type: DisposalTagger
+    tag: trash
+  # Carpmosia-end - Better disposals
 
 - type: entity
   id: MailingUnit


### PR DESCRIPTION
<!-- Read upstream guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- Not following the guidelines or removing any of these sections may result in your PR getting closed. -->

## General information
<!-- Describe your PR as you would to a regular player, omit technical details.
       Make sure to cover all player facing changes as well and as detailed
       as you can, as this will be forwarded to Discord later. -->
Made disposal units automatically tag all items with `trash`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed.
       Link any relevant discussions or issues. -->
This simplifies mapping joint disposals and mailing systems by removing the requirement for 5 morbillion trash taggers

## Technical details
<!-- Describe what code changes you did or will do in this PR and optionally why.
       Feel free to use check boxes to track your progress, for example: -->
- [x] Made disposal units apply a tag if they have the DisposalTaggerComponent
- [x] Gave disposal units the DisposalTaggerComponent with tag `trash`

## Test plan
<!-- Describe how you tested the pull request, and how someone reviewing this PR can test it themselves. -->
Try using a disposals unit in front of a router with tag `trash`

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
       Small fixes/refactors are exempt. Media will be used when forwarded to Discord -->
No

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes,
       prototype renames, and provide instructions for fixing them. -->
No

## Changelog
:cl: <!-- DO NOT REMOVE THIS LINE UNLESS THERE IS NO CHANGELOG -->
<!-- Edit these as you may need, remove/add as many as you want -->
- tweak: Disposal units now automatically tag all items as "trash"
